### PR TITLE
Load data from embedded database.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64 0.12.3",
+ "byteorder",
  "chrono",
  "crossterm",
  "dirs",
@@ -338,6 +339,7 @@ dependencies = [
  "toml",
  "tui",
  "unicode-width",
+ "zerocopy",
 ]
 
 [[package]]
@@ -897,6 +899,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1079,4 +1093,25 @@ checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6580539ad917b7c026220c4b3f2c08d52ce54d6ce0dc491e66002e35388fab46"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d498dbd1fd7beb83c86709ae1c33ca50942889473473d287d56ce4770a18edfb"
+dependencies = [
+ "proc-macro2",
+ "syn",
+ "synstructure",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
+name = "bincode"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30d3a39baa26f9651f17b375061f3233dde33424a8b72b0dbe93a68a0bc896d"
+dependencies = [
+ "byteorder",
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,6 +355,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64 0.12.3",
+ "bincode",
  "byteorder",
  "chrono",
  "crossterm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "chrono"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +155,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_fn"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,24 +168,23 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "crc32fast"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
+checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.8.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
+checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
 dependencies = [
- "autocfg",
- "cfg-if",
- "crossbeam-utils",
+ "cfg-if 1.0.0",
+ "const_fn",
+ "crossbeam-utils 0.8.1",
  "lazy_static",
- "maybe-uninit",
  "memoffset",
  "scopeguard",
 ]
@@ -185,7 +196,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 0.1.10",
+ "lazy_static",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
+dependencies = [
+ "autocfg",
+ "cfg-if 1.0.0",
  "lazy_static",
 ]
 
@@ -312,7 +334,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "wasi",
 ]
@@ -408,9 +430,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.73"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd7d4bd64732af4bf3a67f367c27df8520ad7e230c5817b8ff485864d80242b9"
+checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
 
 [[package]]
 name = "lock_api"
@@ -436,14 +458,8 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
-
-[[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
@@ -453,9 +469,9 @@ checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "memoffset"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c198b026e1bbf08a937e94c6c60f9ec4a2267f5b0d2eec9c1b21b061ce2be55f"
+checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
 dependencies = [
  "autocfg",
 ]
@@ -466,7 +482,7 @@ version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "fuchsia-zircon",
  "fuchsia-zircon-sys",
  "iovec",
@@ -544,7 +560,7 @@ version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "winapi 0.3.9",
 ]
@@ -614,7 +630,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "cloudabi 0.0.3",
  "libc",
  "redox_syscall",
@@ -628,7 +644,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "cloudabi 0.1.0",
  "instant",
  "libc",
@@ -739,7 +755,7 @@ dependencies = [
  "base64 0.11.0",
  "blake2b_simd",
  "constant_time_eq",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
 ]
 
 [[package]]
@@ -814,13 +830,13 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "sled"
-version = "0.34.2"
+version = "0.34.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6a1b592011d7eb727a261d2f80608db11d7f02972c7016e8d4e74e67fe0daf"
+checksum = "1d0132f3e393bcb7390c60bb45769498cf4550bcb7a21d7f95c02b69f6362cdc"
 dependencies = [
  "crc32fast",
  "crossbeam-epoch",
- "crossbeam-utils",
+ "crossbeam-utils 0.8.1",
  "fs2",
  "fxhash",
  "libc",
@@ -840,7 +856,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "redox_syscall",
  "winapi 0.3.9",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+
+[[package]]
 name = "bytes"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,10 +140,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "cloudabi"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "crc32fast"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "lazy_static",
+ "maybe-uninit",
+ "memoffset",
+ "scopeguard",
+]
 
 [[package]]
 name = "crossbeam-utils"
@@ -162,7 +201,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "mio 0.7.0",
- "parking_lot",
+ "parking_lot 0.10.2",
  "signal-hook",
  "winapi 0.3.9",
 ]
@@ -209,6 +248,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +298,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +330,7 @@ dependencies = [
  "scopeguard",
  "serde",
  "serde_json",
+ "sled",
  "structopt",
  "textwrap 0.12.1",
  "thiserror",
@@ -298,6 +357,12 @@ checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "instant"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b141fdc7836c525d4d594027d318c84161ca17aaf8113ab1f81ab93ae897485"
 
 [[package]]
 name = "iovec"
@@ -355,6 +420,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lock_api"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28247cc5a5be2f05fbcd76dd0cf2c7d3b5400cb978a28042abcd4fa0b3f8261c"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,10 +438,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+
+[[package]]
 name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+
+[[package]]
+name = "memoffset"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c198b026e1bbf08a937e94c6c60f9ec4a2267f5b0d2eec9c1b21b061ce2be55f"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mio"
@@ -502,8 +591,19 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
 dependencies = [
- "lock_api",
- "parking_lot_core",
+ "lock_api 0.3.4",
+ "parking_lot_core 0.7.2",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4893845fa2ca272e647da5d0e46660a314ead9c2fdd9a883aabc32e481a8733"
+dependencies = [
+ "instant",
+ "lock_api 0.4.1",
+ "parking_lot_core 0.8.0",
 ]
 
 [[package]]
@@ -513,7 +613,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
 dependencies = [
  "cfg-if",
- "cloudabi",
+ "cloudabi 0.0.3",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
+dependencies = [
+ "cfg-if",
+ "cloudabi 0.1.0",
+ "instant",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -694,6 +809,22 @@ name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+
+[[package]]
+name = "sled"
+version = "0.34.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e6a1b592011d7eb727a261d2f80608db11d7f02972c7016e8d4e74e67fe0daf"
+dependencies = [
+ "crc32fast",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "fs2",
+ "fxhash",
+ "libc",
+ "log",
+ "parking_lot 0.11.0",
+]
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.32"
+bincode = "1.3.1"
 byteorder = "1.3.4"
 chrono = { version = "0.4.13", features = ["serde"] }
 crossterm = { version = "0.17.7", features = ["event-stream"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ unicode-width = "0.1.8"
 textwrap = "0.12.1"
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.57"
-sled = "0.34.2"
+sled = "0.34.6"
 structopt = "0.3.15"
 toml = "0.5.6"
 dirs = "3.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ unicode-width = "0.1.8"
 textwrap = "0.12.1"
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.57"
+sled = "0.34.2"
 structopt = "0.3.15"
 toml = "0.5.6"
 dirs = "3.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.32"
+byteorder = "1.3.4"
 chrono = { version = "0.4.13", features = ["serde"] }
 crossterm = { version = "0.17.7", features = ["event-stream"] }
 tui = { version = "0.10.0", default-features = false, features = ["crossterm"] }
@@ -23,3 +24,4 @@ tokio = { version = "0.2.22", features = ["full"] }
 base64 = "0.12.3"
 itertools = "0.9.0"
 scopeguard = "1.1.0"
+zerocopy = "0.3.0"

--- a/src/app.rs
+++ b/src/app.rs
@@ -35,7 +35,6 @@ pub struct AppData {
 }
 
 impl AppData {
-
     fn init_from_signal(client: &signal::SignalClient) -> anyhow::Result<Self> {
         let groups = client
             .get_groups()

--- a/src/app.rs
+++ b/src/app.rs
@@ -76,7 +76,7 @@ pub struct Channel {
     pub unread_messages: usize,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Message {
     pub from: String,
     #[serde(alias = "text")] // remove

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
-mod storage;
 mod app;
 mod config;
 mod signal;
+mod storage;
 mod ui;
 mod util;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod storage;
 mod app;
 mod config;
 mod signal;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,17 +1,14 @@
-use crate::app::{AppData, Channel, Message};
+use crate::app::{AppData, Channel};
 use crate::util::StatefulList;
 
 use anyhow;
-use byteorder::{BigEndian, LittleEndian};
-use chrono::Utc;
+use byteorder::BigEndian;
 use sled;
 use unicode_width::UnicodeWidthStr;
-use serde::{Serialize, Deserialize};
-use zerocopy::{byteorder::U64, AsBytes, FromBytes, LayoutVerified, Unaligned, U16, U32};
+use zerocopy::{byteorder::U64, AsBytes};
 
 use std::fs::File;
 use std::path::Path;
-use std::str;
 
 pub trait Storage {
     fn save(data: &AppData, path: impl AsRef<Path>) -> anyhow::Result<()>;
@@ -37,12 +34,6 @@ impl Storage for Json {
 
 pub struct Db;
 
-#[derive(Serialize, Deserialize, Debug)]
-struct PersistedMessage {
-    channel_id: u64,
-    message: Message,
-}
-
 impl Db {
     fn load_channels(db: &sled::Db) -> anyhow::Result<Vec<Channel>> {
         let channels = db.open_tree(b"channels")?;
@@ -58,52 +49,10 @@ impl Db {
         Ok(out)
     }
 
-    fn load_messages(db: &sled::Db) -> anyhow::Result<Vec<(u64, Message)>> {
-        let messages = db.open_tree(b"messages")?;
-
-        let mut out = vec![];
-
-        for name_value_res in &messages {
-            let (_id, bytes) = name_value_res?;
-
-            let decoded: PersistedMessage = bincode::deserialize(&bytes[..]).unwrap();
-            out.push((decoded.channel_id, decoded.message));
-        }
-
-        Ok(out)
-    }
-
-    fn join(channels: Vec<Channel>, _messages: Vec<(u64, Message)>) -> anyhow::Result<AppData> {
-        // TODO: join messages with channels
-        Ok(AppData {
-            channels: StatefulList::with_items(channels),
-            input: "hello".to_owned(), // TODO: load
-            input_cursor: 42,          // TODO: load
-        })
-    }
-
     fn save_channel(channels: &sled::Tree, id: u64, channel: &Channel) -> anyhow::Result<()> {
         let encoded: Vec<u8> = bincode::serialize(channel).unwrap();
         let id_value: U64<BigEndian> = U64::new(id);
         channels.insert(id_value.as_bytes(), encoded)?;
-        Ok(())
-    }
-
-    /// Persists a message in a sled tree.
-    /// The layout is `id -> channeld.id + message.message`.
-    fn save_message(
-        messages: &sled::Tree,
-        id: u64,
-        message: &Message,
-        channel_id: u64,
-    ) -> anyhow::Result<()> {
-        
-        let persisted = PersistedMessage {
-            channel_id, message: *message
-        };
-        let encoded: Vec<u8> = bincode::serialize(&persisted).unwrap();
-        let id_value: U64<BigEndian> = U64::new(id);
-        messages.insert(id_value.as_bytes(), encoded)?;
         Ok(())
     }
 }
@@ -111,16 +60,10 @@ impl Db {
 impl Storage for Db {
     fn save(data: &AppData, path: impl AsRef<Path>) -> anyhow::Result<()> {
         let db = sled::open(path)?;
-        let messages = db.open_tree(b"messages")?;
         let channels = db.open_tree(b"channels")?;
 
         for (ch_count, channel) in data.channels.items.iter().enumerate() {
             Self::save_channel(&channels, ch_count as u64, channel)?;
-
-            for (msg_count, message) in channel.messages.iter().enumerate() {
-                let id: u64 = (msg_count as u64) + (ch_count as u64);
-                Self::save_message(&messages, id, message, ch_count as u64)?;
-            }
         }
         Ok(())
     }
@@ -128,9 +71,11 @@ impl Storage for Db {
     fn load(path: impl AsRef<Path>) -> anyhow::Result<AppData> {
         let db = sled::open(path)?;
         let channels = Self::load_channels(&db)?;
-        let messages = Self::load_messages(&db)?;
-        let mut data: AppData = Self::join(channels, messages)?;
-        //data.input_cursor = data.input.width();
+        let data: AppData = AppData {
+            channels: StatefulList::with_items(channels),
+            input: "what should go here?".to_owned(),
+            input_cursor: 0,
+        };
         Ok(data)
     }
 }
@@ -171,5 +116,8 @@ mod tests {
         let loaded_data = Db::load(&data_path).expect("Could not load app data.");
         assert_eq!(loaded_data.input, "hello");
         assert_eq!(loaded_data.channels.items.len(), 1);
+        let channel = loaded_data.channels.items.first().unwrap();
+        assert_eq!(channel.id, "BASIC");
+        assert_eq!(channel.messages.len(), 1);
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,4 +1,5 @@
 use crate::app::{AppData, Channel, Message};
+use crate::util::StatefulList;
 
 use anyhow;
 use byteorder::{BigEndian, LittleEndian};
@@ -77,8 +78,13 @@ impl Db {
         Ok(out)
     }
 
-    fn join(channels: Vec<Channel>, messages: Vec<Message>) -> anyhow::Result<AppData> {
-        unimplemented!()
+    fn join(channels: Vec<Channel>, _messages: Vec<Message>) -> anyhow::Result<AppData> {
+        // TODO: join messages with channels
+        Ok(AppData {
+            channels: StatefulList::with_items(channels),
+            input: "hello".to_owned(), // TODO: load
+            input_cursor: 42,          // TODO: load
+        })
     }
 
     fn save_channel(channels: &sled::Tree, id: u64, channel: &Channel) -> anyhow::Result<()> {
@@ -136,7 +142,6 @@ mod tests {
     // Note this useful idiom: importing names from outer (for mod tests) scope.
     use super::*;
     use crate::app::Message;
-    use crate::util::StatefulList;
     use chrono::{DateTime, NaiveDateTime, Utc};
     use std::env;
 
@@ -167,5 +172,6 @@ mod tests {
 
         let loaded_data = Db::load(&data_path).expect("Could not load app data.");
         assert_eq!(loaded_data.input, "hello");
+        assert_eq!(loaded_data.channels.items.len(), 1);
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,0 +1,64 @@
+use crate::app::{AppData, Channel, Message};
+
+use anyhow;
+use sled;
+use unicode_width::UnicodeWidthStr;
+
+use std::fs::File;
+use std::path::Path;
+
+pub trait Storage {
+
+    fn save(data: &AppData, path: impl AsRef<Path>) -> anyhow::Result<()>;
+
+    fn load(path: impl AsRef<Path>) -> anyhow::Result<AppData>;
+}
+
+pub struct Json;
+impl Storage for Json {
+    fn save(data: &AppData, path: impl AsRef<Path>) -> anyhow::Result<()> {
+        let f = File::create(path)?;
+        serde_json::to_writer(f, data)?;
+        Ok(())
+    }
+
+    fn load(path: impl AsRef<Path>) -> anyhow::Result<AppData> {
+        let f = File::open(path)?;
+        let mut data: AppData = serde_json::from_reader(f)?;
+        data.input_cursor = data.input.width();
+        Ok(data)
+    }
+}
+
+pub struct Db;
+
+impl Db {
+    fn load_channels(db: &sled::Db) -> anyhow::Result<Vec<Channel>> {
+        unimplemented!()
+    }
+
+    fn load_messages(db: &sled::Db) -> anyhow::Result<Vec<Message>> {
+        unimplemented!()
+    }
+
+    fn join(channels: Vec<Channel>, messages: Vec<Message>) -> anyhow::Result<AppData> {
+        unimplemented!()
+    }
+}
+
+impl Storage for Db {
+
+    fn save(data: &AppData, path: impl AsRef<Path>) -> anyhow::Result<()> {
+        unimplemented!()
+    }
+
+    fn load(path: impl AsRef<Path>) -> anyhow::Result<AppData> {
+        let db = sled::open(path)?;
+        let channels = Self::load_channels(&db)?;
+        let messages = Self::load_messages(&db)?;
+        let mut data: AppData = Self::join(channels, messages)?;
+        //data.input_cursor = data.input.width();
+        Ok(data)
+    }
+}
+

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,14 +1,17 @@
 use crate::app::{AppData, Channel, Message};
 
 use anyhow;
+use byteorder::{BigEndian, LittleEndian};
+use chrono::Utc;
 use sled;
 use unicode_width::UnicodeWidthStr;
+use zerocopy::{byteorder::U64, AsBytes, FromBytes, LayoutVerified, Unaligned, U16, U32};
 
 use std::fs::File;
 use std::path::Path;
+use std::str;
 
 pub trait Storage {
-
     fn save(data: &AppData, path: impl AsRef<Path>) -> anyhow::Result<()>;
 
     fn load(path: impl AsRef<Path>) -> anyhow::Result<AppData>;
@@ -38,18 +41,67 @@ impl Db {
     }
 
     fn load_messages(db: &sled::Db) -> anyhow::Result<Vec<Message>> {
-        unimplemented!()
+        let messages = db.open_tree(b"messages")?;
+
+        let mut out = vec![];
+
+        for name_value_res in &messages {
+            let (_id, bytes) = name_value_res?;
+            let content = str::from_utf8(&bytes)?;
+            let message = Message {
+                from: "not saved".to_owned(),
+                message: Some(content.to_owned()),
+                attachments: Vec::new(),
+                arrived_at: Utc::now(),
+            };
+            out.push(message);
+        }
+
+        Ok(out)
     }
 
     fn join(channels: Vec<Channel>, messages: Vec<Message>) -> anyhow::Result<AppData> {
         unimplemented!()
     }
+
+    fn save_channel(channels: &sled::Tree, id: u64, channel: &Channel) -> anyhow::Result<()> {
+        let mut channel_value = vec![];
+        channel_value.extend_from_slice(channel.name.as_bytes());
+        let id_value: U64<BigEndian> = U64::new(id);
+
+        channels.insert(id_value.as_bytes(), channel_value)?;
+        Ok(())
+    }
+
+    fn save_message(messages: &sled::Tree, id: u64, message: &Message) -> anyhow::Result<()> {
+        let content = match message.message {
+            Some(ref s) => s.as_bytes(),
+            None => b"",
+        };
+
+        let mut message_value = vec![];
+        message_value.extend_from_slice(content);
+        let id_value: U64<BigEndian> = U64::new(id);
+        messages.insert(id_value.as_bytes(), message_value)?;
+        Ok(())
+    }
 }
 
 impl Storage for Db {
-
     fn save(data: &AppData, path: impl AsRef<Path>) -> anyhow::Result<()> {
-        unimplemented!()
+        let db = sled::open(path)?;
+        let messages = db.open_tree(b"messages")?;
+        let channels = db.open_tree(b"messages")?;
+
+        for (ch_count, channel) in data.channels.items.iter().enumerate() {
+            Self::save_channel(&channels, ch_count as u64, channel)?;
+
+            for (msg_count, message) in channel.messages.iter().enumerate() {
+                let id: u64 = (msg_count as u64) + (ch_count as u64);
+                Self::save_message(&messages, id, message)?;
+            }
+        }
+        Ok(())
     }
 
     fn load(path: impl AsRef<Path>) -> anyhow::Result<AppData> {
@@ -61,4 +113,3 @@ impl Storage for Db {
         Ok(data)
     }
 }
-


### PR DESCRIPTION
Summary:
This patch introduces sled's embedded database as a storage option for gurk.

Outstanding
- [x] Test with save and load roundtrip
- ~[ ] Join channels and messages~
- [x] Persist all data