### PR TITLE
Follow up on #5.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,22 @@ You need to download and install [`signal-cli`], such that it is found in your `
 1. Download and install `signal-cli`
 2. Follow the instructions at https://github.com/AsamK/signal-cli#usage to register a new client.
 3. Install gurk with `cargo install gurk`
-4. Drop the config file in your `$HOME` folder. For more config options, see [`src/config.rs`].
+4. Drop a config file with the following context
     ```
     [user]
     name = "Your user name"
     phone_number = "Your phone number used in Signal"
     ```
+
+  in one of the following locations:
+
+1. `$XDG_CONFIG_HOME/gurk/gurk.toml`
+2. `$XDG_CONFIG_HOME/gurk.yml`
+3. `$HOME/.config/gurk/gurk.toml`
+4. `$HOME/.gurk.toml`
+
+  For more config options, see [`src/config.rs`].
+
 5. Run `gurk`
 
 At the first run, `gurk` will sync groups and contacts.
@@ -37,7 +47,7 @@ At the first run, `gurk` will sync groups and contacts.
 * Add support for blocked contacts/groups.
 
 The communication with the Signal backend is implemented via [`signal-cli`]. It provides some
-funtionality like lookup of group/contact name only over the dbus interface. Therefore, `gurk` only
+functionality like lookup of group/contact name only over the dbus interface. Therefore, `gurk` only
 works on Linux. We should evaluate if it is possible to switch to the [`libsignal-service-rs`]
 crate.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,7 +51,7 @@ pub fn load_from(path: impl AsRef<Path>) -> anyhow::Result<Config> {
 /// 3. $HOME/.config/gurk/gurk.toml
 /// 4. $HOME/.gurk.toml
 pub fn installed_config() -> Option<PathBuf> {
-    // case 1
+    // case 1, and 3 as fallback (note: case 2 is not possible if 1 is not possible)
     let config_dir = dirs::config_dir()?;
     let config_file = config_dir.join("gurk/gurk.toml");
     if config_file.exists() {
@@ -64,14 +64,8 @@ pub fn installed_config() -> Option<PathBuf> {
         return Some(config_file);
     }
 
-    // case 3
-    let home_dir = dirs::home_dir()?;
-    let config_file = home_dir.join(".config/gurk/gurk.toml");
-    if config_file.exists() {
-        return Some(config_file);
-    }
-
     // case 4
+    let home_dir = dirs::home_dir()?;
     let config_file = home_dir.join(".gurk.toml");
     if config_file.exists() {
         return Some(config_file);


### PR DESCRIPTION
* Support more default config locations (inspired by alacritty).
* Support loading of app data from the legacy data path. After that,
  it is stored at the proper location.
* Add config paths to the README. Resolves #10.

@goolord: You might want to take a look.