### PR TITLE
Fix of new config file creation error by creating missing path dirs

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -39,6 +39,8 @@ impl Config {
         }
         println!("{:?}", self);
         let content = toml::ser::to_string(self)?;
+        let path = config_file.parent().unwrap();
+        std::fs::create_dir_all(path).unwrap();
         std::fs::write(config_file, &content)?;
         Ok(())
     }


### PR DESCRIPTION
Explanation here: https://github.com/boxdot/gurk-rs/issues/43