### PR TITLE
Use group identifier as group channel id.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2037,7 +2037,7 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 [[package]]
 name = "presage"
 version = "0.1.0"
-source = "git+https://github.com/whisperfish/presage.git?branch=main#0de28c2e5c71a684c7544bdb7bf217c168e5b85b"
+source = "git+https://github.com/boxdot/presage.git?rev=25cfb40#25cfb407a2512d194e2fe3cdd34bcf1062ed6cf2"
 dependencies = [
  "async-trait",
  "base64 0.12.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ unicode-width = "0.1.8"
 uuid = "0.8.2"
 whoami = "1.1.2"
 
-presage = { git = "https://github.com/whisperfish/presage.git", branch = "main" }
+presage = { git = "https://github.com/boxdot/presage.git", rev = "25cfb40" }
 
 # [patch."https://github.com/whisperfish/presage.git"]
 # presage = { path = "../presage" }


### PR DESCRIPTION
This identifier can be stored to disk unencrypted and is derived
from the group master key.

This needed as preparation for storing ChannelId as a key in `sled`. 
This allows storing the keys in `sled` unencrypted.