### PR TITLE
Fix colors in white background terminal.

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -283,6 +283,10 @@ impl App {
         self.data.save(&self.config.data_path)
     }
 
+    pub fn self_id(&self) -> Uuid {
+        self.signal_manager.uuid()
+    }
+
     pub fn name_by_id(&self, id: Uuid) -> &str {
         name_by_id(&self.data.names, id)
     }


### PR DESCRIPTION
Also:
* Do not resolve the name and color of the user for each message, but do it before.
* Use a different color for the own user name, when colors conflict in direct chat.

Fixes #16