### PR TITLE
Allow inter-word navigation with Alt/Ctrl+←→

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -459,7 +459,7 @@ impl App {
     }
 
     /// Move a word back
-    pub fn on_alt_left(&mut self) {
+    pub fn move_back_word(&mut self) {
         self.on_left();
         self.word_operation(Self::on_left);
         if self.data.input.as_bytes().get(self.data.input_cursor) == Some(&b' ') {
@@ -468,7 +468,7 @@ impl App {
     }
 
     /// Move a word forward
-    pub fn on_alt_right(&mut self) {
+    pub fn move_forward_word(&mut self) {
         self.word_operation(Self::on_right);
         while self.data.input.as_bytes().get(self.data.input_cursor) == Some(&b' ') {
             self.on_right();

--- a/src/main.rs
+++ b/src/main.rs
@@ -217,22 +217,36 @@ async fn run_single_threaded(relink: bool) -> anyhow::Result<()> {
                     break;
                 }
                 KeyCode::Left => {
-                    app.on_left();
+                    if event
+                        .modifiers
+                        .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
+                    {
+                        app.move_back_word();
+                    } else {
+                        app.on_left();
+                    }
                 }
                 KeyCode::Up if event.modifiers.contains(KeyModifiers::ALT) => app.on_pgup(),
                 KeyCode::Up => app.on_up(),
                 KeyCode::Right => {
-                    app.on_right();
+                    if event
+                        .modifiers
+                        .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
+                    {
+                        app.move_forward_word();
+                    } else {
+                        app.on_right();
+                    }
                 }
                 KeyCode::Down if event.modifiers.contains(KeyModifiers::ALT) => app.on_pgdn(),
                 KeyCode::Down => app.on_down(),
                 KeyCode::PageUp => app.on_pgup(),
                 KeyCode::PageDown => app.on_pgdn(),
                 KeyCode::Char('f') if event.modifiers.contains(KeyModifiers::ALT) => {
-                    app.on_alt_right();
+                    app.move_forward_word();
                 }
                 KeyCode::Char('b') if event.modifiers.contains(KeyModifiers::ALT) => {
-                    app.on_alt_left();
+                    app.move_back_word();
                 }
                 KeyCode::Char('a') if event.modifiers.contains(KeyModifiers::CONTROL) => {
                     app.on_home();
@@ -243,7 +257,11 @@ async fn run_single_threaded(relink: bool) -> anyhow::Result<()> {
                 KeyCode::Char('w') if event.modifiers.contains(KeyModifiers::CONTROL) => {
                     app.on_delete_word();
                 }
-                KeyCode::Backspace if event.modifiers.contains(KeyModifiers::ALT) => {
+                KeyCode::Backspace
+                    if event
+                        .modifiers
+                        .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+                {
                     app.on_delete_word();
                 }
                 KeyCode::Char('k') if event.modifiers.contains(KeyModifiers::CONTROL) => {


### PR DESCRIPTION
This patch allows the user to navigate words using Ctrl/Alt in combination with the arrow keys (and removing words by combining them with the Del key).

Feel free to ignore this patch if it's not in line with the keyboard shortcuts scheme you want to have for Gurk. I just thought I'd contribute it upstream as well in case it's useful to others as well.