### PR TITLE
Change channel with alt+1/2/..

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -414,6 +414,13 @@ impl App {
         self.data.channels.next();
     }
 
+    pub fn select_channel(&mut self, channel_idx: usize) {
+        if self.reset_unread_messages() {
+            self.save().unwrap();
+        }
+        self.data.channels.select(channel_idx);
+    }
+
     pub fn on_pgup(&mut self) {
         let select = self.data.channels.state.selected().unwrap_or_default();
         self.data.channels.items[select].messages.next();

--- a/src/main.rs
+++ b/src/main.rs
@@ -268,6 +268,36 @@ async fn run_single_threaded(relink: bool) -> anyhow::Result<()> {
                 KeyCode::Char('k') if event.modifiers.contains(KeyModifiers::CONTROL) => {
                     app.on_delete_suffix();
                 }
+                KeyCode::Char('1') if event.modifiers.contains(KeyModifiers::ALT) => {
+                    app.select_channel(0);
+                }
+                KeyCode::Char('2') if event.modifiers.contains(KeyModifiers::ALT) => {
+                    app.select_channel(1);
+                }
+                KeyCode::Char('3') if event.modifiers.contains(KeyModifiers::ALT) => {
+                    app.select_channel(2);
+                }
+                KeyCode::Char('4') if event.modifiers.contains(KeyModifiers::ALT) => {
+                    app.select_channel(3);
+                }
+                KeyCode::Char('5') if event.modifiers.contains(KeyModifiers::ALT) => {
+                    app.select_channel(4);
+                }
+                KeyCode::Char('6') if event.modifiers.contains(KeyModifiers::ALT) => {
+                    app.select_channel(5);
+                }
+                KeyCode::Char('7') if event.modifiers.contains(KeyModifiers::ALT) => {
+                    app.select_channel(6);
+                }
+                KeyCode::Char('8') if event.modifiers.contains(KeyModifiers::ALT) => {
+                    app.select_channel(7);
+                }
+                KeyCode::Char('9') if event.modifiers.contains(KeyModifiers::ALT) => {
+                    app.select_channel(8);
+                }
+                KeyCode::Char('0') if event.modifiers.contains(KeyModifiers::ALT) => {
+                    app.select_channel(9);
+                }
                 code => app.on_key(code).await,
             },
             Some(Event::Message(content)) => {

--- a/src/util.rs
+++ b/src/util.rs
@@ -84,6 +84,12 @@ impl<T> StatefulList<T> {
         };
         self.state.select(Some(i));
     }
+
+    pub fn select(&mut self, channel_idx: usize) {
+        if channel_idx < self.items.len() {
+            self.state.select(Some(channel_idx));
+        }
+    }
 }
 
 pub fn utc_timestamp_msec_to_local(timestamp: u64) -> DateTime<Local> {


### PR DESCRIPTION
Sadly ctrl+1/2/.. keybindings do not seem to work well since these are not
mapped to dedicated escape sequences in terminals. 

Using Alt instead does work.

I'm not sure how useful this actually is when ctrl+j/k already works, so feel
free to close this.