### PR TITLE
Add cross compilation targets to CI and fix publish workflow.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,62 +1,178 @@
 on: [push, pull_request]
 
-name: CI
+name: ci
 
 env:
   CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  RUSTFLAGS: "-D warnings"
+  RUSTUP_MAX_RETRIES: 10
+  FETCH_DEPTH: 0
+  NIGHTLY_VERSION: nightly-2021-06-08
 
 jobs:
-  build_and_test:
-    name: build
-    runs-on: ubuntu-latest
-    env:
-      RUSTFLAGS: -D warnings
-    steps:
-      - name: Install build dependencies for libdbus-sys
-        run: |
-          sudo apt update
-          sudo apt install -y libdbus-1-dev pkg-config
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --all-targets --all-features
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-
   rustfmt:
     name: rustfmt
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - name: Checkout repository
+        uses: actions/checkout@v2
         with:
-          profile: minimal
+          fetch-depth: ${{ env.FETCH_DEPTH }}
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
           toolchain: stable
+          profile: minimal
           components: rustfmt
-      - uses: actions-rs/cargo@v1
+      - name: Check format
+        uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: -- --check
 
   clippy:
     name: clippy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
-      - name: Install build dependencies for libdbus-sys
-        run: |
-          sudo apt update
-          sudo apt install -y libdbus-1-dev pkg-config
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - name: Checkout repository
+        uses: actions/checkout@v2
         with:
-          profile: minimal
+          fetch-depth: ${{ env.FETCH_DEPTH }}
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
           toolchain: stable
+          profile: minimal
           components: clippy
-      - uses: actions-rs/cargo@v1
+      - name: Clippy
+        uses: actions-rs/cargo@v1
         with:
           command: clippy
+
+  build-test-x86_64-unknown-linux-gnu:
+    name: build and test (x86_64-unknown-linux-gnu)
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: ${{ env.FETCH_DEPTH }}
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  build-x86_64-unknown-linux-musl:
+    name: build (x86_64-unknown-linux-musl)
+    runs-on: ubuntu-latest
+    container:
+      image: rust:alpine
+      volumes:
+        - /usr/local/cargo/registry
+    env:
+      # For some reason `-crt-static` is not working for clang without lld
+      RUSTFLAGS: "-C link-arg=-fuse-ld=lld -C target-feature=-crt-static"
+    steps:
+      - name: Install dependencies
+        run: apk add --no-cache musl-dev lld protoc
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: ${{ env.FETCH_DEPTH }}
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          target: x86_64-unknown-linux-musl
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --target x86_64-unknown-linux-musl
+
+  build-aarch64-unknown-linux-gnu:
+    name: build (aarch64-unknown-linux-gnu)
+    runs-on: ubuntu-18.04
+    env:
+      CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: ${{ env.FETCH_DEPTH }}
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.NIGHTLY_VERSION }}
+          target: aarch64-unknown-linux-gnu
+          profile: minimal
+          override: true
+      - name: Install target toolchain
+        run: sudo apt-get install gcc-aarch64-linux-gnu
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --target aarch64-unknown-linux-gnu
+
+  build-test-x86_64-apple-darwin:
+    name: build and test (x86_64-apple-darwin)
+    runs-on: macos-latest
+    env:
+      SELECT_XCODE: /Applications/Xcode_12.2.app
+    steps:
+      - name: Select XCode version
+        run: sudo xcode-select -s "${SELECT_XCODE}"
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: ${{ env.FETCH_DEPTH }}
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  build-aarch64-apple-darwin:
+    name: build (aarch64-apple-darwin)
+    runs-on: macos-latest
+    env:
+      SELECT_XCODE: /Applications/Xcode_12.2.app
+    steps:
+      - name: Select XCode version
+        run: sudo xcode-select -s "${SELECT_XCODE}"
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: ${{ env.FETCH_DEPTH }}
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.NIGHTLY_VERSION }}
+          target: aarch64-apple-darwin
+          profile: minimal
+          override: true
+      - name: Build
+        run: |
+          export SDKROOT=$(xcrun -sdk macosx11.0 --show-sdk-path)
+          export MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.0 --show-sdk-platform-version)
+          cargo build --target aarch64-apple-darwin

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,94 +7,85 @@ on:
 env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
-  RUSTFLAGS: "-D warnings -W unreachable-pub"
+  RUSTFLAGS: "-D warnings"
   RUSTUP_MAX_RETRIES: 10
   FETCH_DEPTH: 0 # pull in the tags for the version string
+  NIGHTLY_VERSION: nightly-2021-06-08
 
 jobs:
   dist-changelog:
     name: dist (changelog)
     runs-on: ubuntu-18.04
-
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: ${{ env.FETCH_DEPTH }}
-
-    - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        profile: minimal
-        override: true
-        components: rust-src
-
-    - name: Generate checklog
-      run: cargo xtask changelog
-
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: dist-changelog
-        path: dist
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: ${{ env.FETCH_DEPTH }}
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+      - name: Generate checklog
+        run: cargo xtask changelog
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist-changelog
+          path: dist
 
   dist-x86_64-unknown-linux-gnu:
     name: dist (x86_64-unknown-linux-gnu)
     runs-on: ubuntu-18.04
-
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: ${{ env.FETCH_DEPTH }}
-
-    - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        profile: minimal
-        override: true
-        components: rust-src
-
-    - name: Dist
-      run: cargo xtask dist
-
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: dist-x86_64-unknown-linux-gnu
-        path: dist
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: ${{ env.FETCH_DEPTH }}
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+      - name: Dist
+        run: cargo xtask dist
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist-x86_64-unknown-linux-gnu
+          path: dist
 
   dist-x86_64-unknown-linux-musl:
     name: dist (x86_64-unknown-linux-musl)
     runs-on: ubuntu-20.04
+    container:
+      image: rust:alpine
+      volumes:
+        - /usr/local/cargo/registry
     env:
       # For some reason `-crt-static` is not working for clang without lld
       GURK_TARGET: x86_64-unknown-linux-musl
       RUSTFLAGS: "-C link-arg=-fuse-ld=lld -C target-feature=-crt-static"
-    container:
-      image: rust:alpine
-      volumes:
-      - /usr/local/cargo/registry
-
     steps:
-    - name: Install dependencies
-      run: apk add --no-cache git clang lld musl-dev
-
-    - name: Checkout repository
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: ${{ env.FETCH_DEPTH }}
-
-    - name: Dist
-      run: cargo xtask dist
-
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: dist-x86_64-unknown-linux-musl
-        path: dist
+      - name: Install dependencies
+        run: apk add --no-cache musl-dev clang lld protoc
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: ${{ env.FETCH_DEPTH }}
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          target: x86_64-unknown-linux-musl
+      - name: Dist
+        run: cargo xtask dist
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist-x86_64-unknown-linux-musl
+          path: dist
 
   dist-aarch64-unknown-linux-gnu:
     name: dist (aarch64-unknown-linux-gnu)
@@ -102,32 +93,27 @@ jobs:
     env:
       GURK_TARGET: aarch64-unknown-linux-gnu
       CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
-
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: ${{ env.FETCH_DEPTH }}
-
-    - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        target: aarch64-unknown-linux-gnu
-        profile: minimal
-        override: true
-
-    - name: Install target toolchain
-      run: sudo apt-get install gcc-aarch64-linux-gnu
-
-    - name: Dist
-      run: cargo xtask dist
-
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: dist-aarch64-unknown-linux-gnu
-        path: dist
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: ${{ env.FETCH_DEPTH }}
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.NIGHTLY_VERSION }}
+          target: aarch64-unknown-linux-gnu
+          profile: minimal
+          override: true
+      - name: Install target toolchain
+        run: sudo apt-get install gcc-aarch64-linux-gnu
+      - name: Dist
+        run: cargo xtask dist
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist-aarch64-unknown-linux-gnu
+          path: dist
 
   dist-x86_64-apple-darwin:
     name: dist (x86_64-apple-darwin)
@@ -135,31 +121,25 @@ jobs:
     env:
       GURK_TARGET: x86_64-apple-darwin
       SELECT_XCODE: /Applications/Xcode_12.2.app
-
     steps:
-    - name: Select XCode version
-      run: sudo xcode-select -s "${SELECT_XCODE}"
-
-    - name: Checkout repository
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: ${{ env.FETCH_DEPTH }}
-
-    - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        profile: minimal
-        override: true
-
-    - name: Dist
-      run: cargo xtask dist
-
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: dist-x86_64-apple-darwin
-        path: dist
+      - name: Select XCode version
+        run: sudo xcode-select -s "${SELECT_XCODE}"
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: ${{ env.FETCH_DEPTH }}
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+      - name: Dist
+        run: cargo xtask dist
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist-x86_64-apple-darwin
+          path: dist
 
   dist-aarch64-apple-darwin:
     name: dist (aarch64-apple-darwin)
@@ -167,32 +147,30 @@ jobs:
     env:
       GURK_TARGET: aarch64-apple-darwin
       SELECT_XCODE: /Applications/Xcode_12.2.app
-
     steps:
-    - name: Select XCode version
-      run: sudo xcode-select -s "${SELECT_XCODE}"
-
-    - name: Checkout repository
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: ${{ env.FETCH_DEPTH }}
-
-    - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        target: aarch64-apple-darwin
-        profile: minimal
-        override: true
-
-    - name: Dist
-      run: SDKROOT=$(xcrun -sdk macosx11.0 --show-sdk-path) MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.0 --show-sdk-platform-version) cargo xtask dist
-
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: dist-aarch64-apple-darwin
-        path: dist
+      - name: Select XCode version
+        run: sudo xcode-select -s "${SELECT_XCODE}"
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: ${{ env.FETCH_DEPTH }}
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.NIGHTLY_VERSION }}
+          target: aarch64-apple-darwin
+          profile: minimal
+          override: true
+      - name: Dist
+        run: |
+          export SDKROOT=$(xcrun -sdk macosx11.0 --show-sdk-path)
+          export MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.0 --show-sdk-platform-version)
+          cargo xtask dist
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist-aarch64-apple-darwin
+          path: dist
 
   publish:
     name: publish
@@ -204,7 +182,6 @@ jobs:
       - dist-aarch64-unknown-linux-gnu
       - dist-x86_64-apple-darwin
       - dist-aarch64-apple-darwin
-
     steps:
       - uses: actions/download-artifact@v2
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,18 @@ keywords = ["signal", "tui"]
 repository = "https://github.com/boxdot/gurk-rs"
 license = "AGPL-3.0-only"
 categories = ["command-line-utilities"]
+resolver = "2"
 
 [workspace]
 members = ["xtask"]
+
+[profile.dev.package]
+# This speeds up `cargo xtask dist`.
+miniz_oxide.opt-level = 3
+
+[profile.release]
+lto = "thin"
+debug = 0
 
 [dependencies]
 anyhow = "1.0.40"

--- a/xtask/src/dist.rs
+++ b/xtask/src/dist.rs
@@ -19,10 +19,6 @@ impl flags::Dist {
 
 fn build() -> Result<()> {
     let target = get_target();
-    if target.contains("-linux-gnu") || target.contains("-linux-musl") {
-        env::set_var("CC", "clang");
-    }
-
     cmd!("cargo build --target {target} --release --locked").run()?;
 
     let suffix = exe_suffix(&target);
@@ -42,8 +38,6 @@ fn get_target() -> String {
         _ => {
             if cfg!(target_os = "linux") {
                 "x86_64-unknown-linux-gnu".to_string()
-            } else if cfg!(target_os = "windows") {
-                "x86_64-pc-windows-msvc".to_string()
             } else if cfg!(target_os = "macos") {
                 "x86_64-apple-darwin".to_string()
             } else {


### PR DESCRIPTION
Also fix the publish workflow to compile arm targets on nightly.
Nightly is required since signal-client is using the armv8 feature
in aes which is only available on nightly. We use the version of
nightly which is defined in the toolchain file of signal-client.

Another fix is not to use clang for native compilation. It fails
for arm cross compilation.