### PR TITLE
Add gurk package name to cargo install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 Download a pre-compiled binary from [Releases], or install from source:
 
 ```shell
-cargo install --git https://github.com/boxdot/gurk-rs
+cargo install --git https://github.com/boxdot/gurk-rs gurk
 ```
 
 Run


### PR DESCRIPTION
The original install instructions in the README.md (`cargo install --git https://github.com/boxdot/gurk-rs`) now result in the following error since the introduction of xtask: 
```
error: multiple packages with binaries found: gurk, xtask
```
There is a cargo issue about this here: https://github.com/rust-lang/cargo/issues/3049 and the reported solution was to specify the package name after the git repo URL. I tried this for installing gurk and it worked. 