### PR TITLE
Update gurk verson in Cargo.lock to match Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "gurk"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
I assume the Cargo.lock wasn't updated because a `cargo build` or `cargo update` wasn't run after the version number was updated in the Cargo.toml (and before https://github.com/boxdot/gurk-rs/commit/0045ff58a1b2a947f4cf7a2db96df8b3f95f7db5 was committed).