### PR TITLE
Check of subtract to avoid overflow error in ui.rs fn draw_messages 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fix formatting of phone number and update user name on start. ([#78])
+- Fix an overflow error and crash by adding a subtraction check. ([#88])
 
 [#78]: https://github.com/boxdot/gurk-rs/pull/78
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -297,7 +297,14 @@ fn display_message(
     }
 
     let from = Span::styled(
-        textwrap::indent(&from, &" ".repeat(max_username_width - from.width())),
+        textwrap::indent(
+            &from,
+            &" ".repeat(
+                max_username_width
+                    .checked_sub(from.width())
+                    .unwrap_or_default(),
+            ),
+        ),
         Style::default().fg(from_color),
     );
     let delimeter = Span::from(": ");


### PR DESCRIPTION
See issue #87. 