### PR TITLE
Minimize side effects in config and add tests.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1001,6 +1001,7 @@ dependencies = [
  "serde",
  "serde_json",
  "structopt",
+ "tempfile",
  "textwrap 0.14.2",
  "tokio",
  "tokio-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ version = "0.2.1"
 [workspace]
 members = ["xtask"]
 
-[profile.dev.package]
+[profile.dev.package.miniz_oxide]
 # This speeds up `cargo xtask dist`.
-miniz_oxide.opt-level = 3
+opt-level = 3
 
 [profile.release]
 debug = 0
@@ -50,6 +50,9 @@ whoami = "1.1.2"
 
 phonenumber = "0.3.1"
 presage = {git = "https://github.com/whisperfish/presage.git", rev = "20f8be16"}
+
+[dev-dependencies]
+tempfile = "3.2.0"
 
 # [patch."https://github.com/whisperfish/presage.git"]
 # presage = { path = "../presage" }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,19 +1,30 @@
-use anyhow::{anyhow, bail};
+use anyhow::{anyhow, bail, Context};
 use serde::{Deserialize, Serialize};
 
 use std::fs;
 use std::path::{Path, PathBuf};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Config {
+    /// Path to the JSON file (incl. filename) storing channels and messages.
     #[serde(default = "default_data_path")]
     pub data_path: PathBuf,
+    /// Path to the Signal database containing the linked device data.
     #[serde(default = "default_signal_db_path")]
     pub signal_db_path: PathBuf,
     /// Whether only to show the first name of a contact
     #[serde(default)]
     pub first_name_only: bool,
+    /// User configuration
     pub user: User,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct User {
+    /// Name to be shown in the application
+    pub name: String,
+    /// Phone number used in Signal
+    pub phone_number: String,
 }
 
 impl Config {
@@ -27,51 +38,63 @@ impl Config {
         }
     }
 
+    /// Tries to load configuration from one of the default locations:
+    ///
+    /// 1. $XDG_CONFIG_HOME/gurk/gurk.toml
+    /// 2. $XDG_CONFIG_HOME/gurk.toml
+    /// 3. $HOME/.config/gurk/gurk.toml
+    /// 4. $HOME/.gurk.toml
+    ///
+    /// If no config is found returns `None`.
+    pub fn load_installed() -> anyhow::Result<Option<Self>> {
+        installed_config().map(Self::load).transpose()
+    }
+
+    /// Saves a new config file in case it does not exist.
+    ///
+    /// Also makes sure that the `config.data_path` exists.
     pub fn save_new(&self) -> anyhow::Result<()> {
         let config_dir =
             dirs::config_dir().ok_or_else(|| anyhow!("could not find default config directory"))?;
         let config_file = config_dir.join("gurk/gurk.toml");
-        if config_file.exists() {
+        self.save_new_at(config_file)
+    }
+
+    fn save_new_at(&self, path: impl AsRef<Path>) -> anyhow::Result<()> {
+        // check that config won't be overridden
+        if path.as_ref().exists() {
             bail!(
                 "will not override config file at: {}",
-                config_file.display()
+                path.as_ref().display()
             );
         }
-        println!("{:?}", self);
+
+        // make sure data_path exists
+        let data_path = self
+            .data_path
+            .parent()
+            .ok_or_else(|| anyhow!("invalid data path: no parent dir"))?;
+        fs::create_dir_all(data_path).context("could not create data dir")?;
+
+        self.save(path)
+    }
+
+    fn load(path: impl AsRef<Path>) -> anyhow::Result<Config> {
+        let content = std::fs::read_to_string(path)?;
+        let config = toml::de::from_str(&content)?;
+        Ok(config)
+    }
+
+    fn save(&self, path: impl AsRef<Path>) -> anyhow::Result<()> {
+        let path = path.as_ref();
         let content = toml::ser::to_string(self)?;
-        let path = config_file.parent().unwrap();
-        std::fs::create_dir_all(path).unwrap();
-        std::fs::write(config_file, &content)?;
+        let parent_dir = path
+            .parent()
+            .ok_or_else(|| anyhow!("invalid config path {}: no parent dir", path.display()))?;
+        fs::create_dir_all(parent_dir).unwrap();
+        fs::write(path, &content)?;
         Ok(())
     }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct User {
-    /// Name to be shown in the application
-    pub name: String,
-    /// Phone number used in Signal
-    pub phone_number: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SignalCli {
-    /// Path to the signal-cli executable.
-    pub path: PathBuf,
-}
-
-impl Default for SignalCli {
-    fn default() -> Self {
-        Self {
-            path: PathBuf::from("signal-cli"),
-        }
-    }
-}
-
-pub fn load_from(path: impl AsRef<Path>) -> anyhow::Result<Config> {
-    let content = std::fs::read_to_string(path)?;
-    let config = toml::de::from_str(&content)?;
-    Ok(config)
 }
 
 /// Get the location of the first found default config file paths
@@ -81,7 +104,7 @@ pub fn load_from(path: impl AsRef<Path>) -> anyhow::Result<Config> {
 /// 2. $XDG_CONFIG_HOME/gurk.yml
 /// 3. $HOME/.config/gurk/gurk.toml
 /// 4. $HOME/.gurk.toml
-pub fn installed_config() -> Option<PathBuf> {
+fn installed_config() -> Option<PathBuf> {
     // case 1, and 3 as fallback (note: case 2 is not possible if 1 is not possible)
     let config_dir = dirs::config_dir()?;
     let config_file = config_dir.join("gurk/gurk.toml");
@@ -105,20 +128,7 @@ pub fn installed_config() -> Option<PathBuf> {
     None
 }
 
-pub fn default_data_dir() -> PathBuf {
-    let data_dir = match dirs::data_dir() {
-        Some(dir) => dir.join("gurk"),
-        None => panic!("default data directory not found, $XDG_DATA_HOME and $HOME are unset"),
-    };
-    fs::create_dir_all(&data_dir)
-        .unwrap_or_else(|_| panic!("{:?} did not exist and could not be created", &data_dir));
-    data_dir
-}
-
-fn default_data_path() -> PathBuf {
-    default_data_dir().join("gurk.data.json")
-}
-
+/// Path to store the signal database containing the data for the linked device.
 pub fn default_signal_db_path() -> PathBuf {
     default_data_dir().join("signal-db")
 }
@@ -126,4 +136,71 @@ pub fn default_signal_db_path() -> PathBuf {
 /// Fallback to legacy data path location
 pub fn fallback_data_path() -> Option<PathBuf> {
     dirs::home_dir().map(|p| p.join(".gurk.data.json"))
+}
+
+fn default_data_dir() -> PathBuf {
+    match dirs::data_dir() {
+        Some(dir) => dir.join("gurk"),
+        None => panic!("default data directory not found, $XDG_DATA_HOME and $HOME are unset"),
+    }
+}
+
+fn default_data_path() -> PathBuf {
+    default_data_dir().join("gurk.data.json")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::{tempdir, NamedTempFile, TempDir};
+
+    fn example_user() -> User {
+        User {
+            name: "Tyler Durden".to_string(),
+            phone_number: "+0000000000".to_string(),
+        }
+    }
+
+    fn example_config_with_random_paths(dir: &TempDir) -> Config {
+        let data_path = dir.path().join("some-data-dir/some-other-dir/data.json");
+        assert!(!data_path.parent().unwrap().exists());
+        let signal_db_path = dir.path().join("some-signal-db-dir/some-other-dir");
+        assert!(!signal_db_path.exists());
+
+        Config {
+            data_path,
+            signal_db_path,
+            ..Config::with_user(example_user())
+        }
+    }
+
+    #[test]
+    fn test_save_new_at_non_existent() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+
+        let config = example_config_with_random_paths(&dir);
+        let config_path = dir.path().join("some-dir/some-other-dir/gurk.toml");
+
+        config.save_new_at(&config_path)?;
+        let loaded_config = Config::load(config_path)?;
+        assert_eq!(config, loaded_config);
+
+        assert!(config.data_path.parent().unwrap().exists()); // data path parent is created
+        assert!(!config.signal_db_path.exists()); // signal path is not touched
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_save_new_fails_or_existent() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let config = example_config_with_random_paths(&dir);
+        let file = NamedTempFile::new()?;
+
+        assert!(config.save_new_at(file.path()).is_err());
+        assert!(!config.data_path.parent().unwrap().exists()); // data path parent is not touched
+        assert!(!config.signal_db_path.exists()); // signal path is not touched
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
Config now only ensures that the config dir and the data dir both
exist on save. The signal db path is not touched, since it created
automatically by presage's storage.