### PR TITLE
Send attachments from file:// paths.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@
 
 - Add basic emojis and reactions support. ([#91])
 - Open URL (if any) in selected message on Enter when input is empty. ([#99])
+- Send attachments from file:// paths (#[100]).
 
 [#91]: https://github.com/boxdot/gurk-rs/pull/91
 [#99]: https://github.com/boxdot/gurk-rs/pull/99
+[#100]: https://github.com/boxdot/gurk-rs/pull/100
 
 ## 0.2.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,6 +1006,7 @@ dependencies = [
  "log",
  "log-panics",
  "log4rs",
+ "mime_guess",
  "notify-rust",
  "opener 0.5.0",
  "phonenumber",
@@ -1349,7 +1350,7 @@ checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 [[package]]
 name = "libsignal-protocol"
 version = "0.1.0"
-source = "git+https://github.com/signalapp/libsignal-client#528aec7e26f96411d9236011303f1c441f6e7b70"
+source = "git+https://github.com/signalapp/libsignal-client#72ba4e6959d80b4f091fade5373e5d9aae966c01"
 dependencies = [
  "aes",
  "aes-gcm-siv",
@@ -1373,7 +1374,7 @@ dependencies = [
 [[package]]
 name = "libsignal-service"
 version = "0.1.0"
-source = "git+https://github.com/whisperfish/libsignal-service-rs#4e32da1e6fdb23fb1c43700ee5ec577da1c23175"
+source = "git+https://github.com/whisperfish/libsignal-service-rs#7d6fce5f56fdcc554545e60852f9750ebd52ef29"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1405,7 +1406,7 @@ dependencies = [
 [[package]]
 name = "libsignal-service-hyper"
 version = "0.1.0"
-source = "git+https://github.com/whisperfish/libsignal-service-rs#4e32da1e6fdb23fb1c43700ee5ec577da1c23175"
+source = "git+https://github.com/whisperfish/libsignal-service-rs#7d6fce5f56fdcc554545e60852f9750ebd52ef29"
 dependencies = [
  "async-trait",
  "async-tungstenite",
@@ -2051,7 +2052,7 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 [[package]]
 name = "presage"
 version = "0.1.0"
-source = "git+https://github.com/whisperfish/presage.git?rev=20f8be16#20f8be16dc3b9783a576f60b5d642097283295d4"
+source = "git+https://github.com/whisperfish/presage.git?rev=b07abef#b07abeffc8682313d896b0b6c153b21a59c0ca1e"
 dependencies = [
  "async-trait",
  "base64 0.12.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ debug = 0
 lto = "thin"
 
 [dependencies]
-presage = { git = "https://github.com/whisperfish/presage.git", rev = "20f8be16" }
+presage = { git = "https://github.com/whisperfish/presage.git", rev = "b07abef" }
 
 anyhow = "1.0.40"
 async-trait = "0.1.51"
@@ -37,6 +37,7 @@ itertools = "0.10.0"
 log = "0.4.14"
 log-panics = "2.0.0"
 log4rs = "1.0.0"
+mime_guess = "2.0.3"
 notify-rust = "4.5.0"
 opener = "0.5.0"
 phonenumber = "0.3.1"

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ libraries that are not available on crates.io.
 * [ ] Mouse navigation (works for channels, missing for the messages list).
 * [ ] Search of messages/chats. Add quick switch between chats by name.
 * [ ] Multiline messages; the `Enter` key sends the message.
-* [ ] Viewing/sending of attachments.
+* [ ] Viewing/sending of attachments (sending works).
 * [ ] Support for blocked contacts/groups.
 * [x] Reactions with emojis.
 * [x] Open URL in selected message.

--- a/src/util.rs
+++ b/src/util.rs
@@ -120,6 +120,7 @@ pub fn is_phone_number(s: impl AsRef<str>) -> bool {
 pub const URL_REGEX: &str =
     "(ipfs:|ipns:|magnet:|mailto:|gemini:|gopher:|https:|http:|news:|file:|git:|ssh:|ftp:)\
      [^\u{0000}-\u{001F}\u{007F}-\u{009F}<>\"\\s{-}\\^⟨⟩`]+";
+pub const ATTACHMENT_REGEX: &str = "file:[^\u{0000}-\u{001F}\u{007F}-\u{009F}<>\"\\s{-}\\^⟨⟩`]+";
 
 /// Regex which is compiled on demand, to avoid expensive computations at startup.
 ///


### PR DESCRIPTION
Any file:// paths included in an outgoing message is sent as
attachment. Since we don't have yet storing and viewing of
attachments, we just show a replacement text if the message contains
only attachments. Otherwise, we show the message with attachments
paths removed.