### PR TITLE
Fix and isolate message receipts

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -99,12 +99,13 @@ impl ReceiptHandler {
                     if u.is_empty() {
                         e.remove_entry();
                     }
-                    return true;
+                    true
+                } else {
+                    false
                 }
             }
-            Entry::Vacant(_) => {}
-        };
-        false
+            Entry::Vacant(_) => false,
+        }
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -97,14 +97,13 @@ impl ReceiptHandler {
                 if let Some((timestamps, receipt)) = u.get_data() {
                     signal_manager.send_receipt(uuid, timestamps, receipt);
                     if u.is_empty() {
-                        self.receipt_set.remove_entry(&uuid);
+                        e.remove_entry();
                     }
                     return true;
                 }
             }
             Entry::Vacant(_) => {}
         };
-        self.receipt_set.remove_entry(&uuid);
         false
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -115,7 +115,7 @@ pub struct ReceiptEvent {
     uuid: Uuid,
     /// Timestamp of the messages
     timestamp: u64,
-    /// Type : Received, Read
+    /// Type : Received, Delivered
     receipt_type: Receipt,
 }
 
@@ -154,14 +154,14 @@ impl ReceiptQueues {
         // in the case a message is immediatly received and read.
         self.received_msg.remove(&timestamp);
         if !self.read_msg.insert(timestamp) {
-            log::error!("Somehow got duplicate Read receipt @ {}", timestamp);
+            log::error!("Somehow got duplicate Delivered receipt @ {}", timestamp);
         }
     }
 
     pub fn add(&mut self, timestamp: u64, receipt: Receipt) {
         match receipt {
             Receipt::Received => self.add_received(timestamp),
-            Receipt::Read => self.add_read(timestamp),
+            Receipt::Delivered => self.add_read(timestamp),
             _ => {}
         }
     }
@@ -173,7 +173,7 @@ impl ReceiptQueues {
         }
         if !self.read_msg.is_empty() {
             let timestamps = self.read_msg.drain().collect::<Vec<u64>>();
-            return Some((timestamps, Receipt::Read));
+            return Some((timestamps, Receipt::Delivered));
         }
         None
     }
@@ -505,7 +505,7 @@ pub enum Receipt {
     Nothing, // Do not do anything to these receipts in order to avoid spamming receipt messages when an old database is loaded
     Sent,
     Received,
-    Read,
+    Delivered,
 }
 
 impl Default for Receipt {
@@ -520,7 +520,7 @@ impl Receipt {
             Self::Nothing => "",
             Self::Sent => "(x)",
             Self::Received => "(xx)",
-            Self::Read => "(xxx)",
+            Self::Delivered => "(xxx)",
         }
     }
 
@@ -531,14 +531,14 @@ impl Receipt {
     pub fn from_i32(i: i32) -> Self {
         match i {
             0 => Self::Received,
-            1 => Self::Read,
+            1 => Self::Delivered,
             _ => Self::Nothing,
         }
     }
 
     pub fn to_i32(self) -> i32 {
         match self {
-            Self::Read => 1,
+            Self::Delivered => 1,
             _ => 0,
         }
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -368,7 +368,7 @@ impl TypingAction {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum Receipt {
-    Nothing,
+    Nothing, // Do not do anything to these receipts in order to avoid spamming receipt messages when an old database is loaded
     Sent,
     Received,
     Read,
@@ -434,7 +434,7 @@ impl Message {
             quote: None,
             attachments: Default::default(),
             reactions: Default::default(),
-            receipt: Default::default(),
+            receipt: Receipt::Sent,
         }
     }
 
@@ -446,7 +446,7 @@ impl Message {
             quote: None,
             attachments: Default::default(),
             reactions: Default::default(),
-            receipt: Default::default(),
+            receipt: Receipt::Sent,
         })
     }
 }
@@ -998,9 +998,10 @@ impl App {
         Ok(())
     }
 
-    pub fn send_receipts(&self, channel: &Channel, timestamps: Vec<u64>, receipt: Receipt) {
+    pub fn send_receipts(&self, channel: &Channel, timestamps: Vec<u64>, receipt: Receipt)  -> anyhow::Result<()> {
         self.signal_manager
-            .send_receipt(channel, self.user_id, timestamps, receipt)
+            .send_receipt(channel, self.user_id, timestamps, receipt);
+        self.save()
     }
 
     fn handle_typing(

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,12 +171,13 @@ async fn run_single_threaded(relink: bool) -> anyhow::Result<()> {
     let tick_tx = tx.clone();
     // Tick to trigger receipt sending
     tokio::spawn(async move {
+        let mut interval = tokio::time::interval(RECEIPT_BUDGET);
         loop {
+            interval.tick().await;
             tick_tx
                 .send(Event::Tick)
                 .await
                 .expect("Cannot tick: events channel closed.");
-            tokio::time::sleep(RECEIPT_BUDGET).await;
         }
     });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,9 @@ use std::time::{Duration, Instant};
 use crate::{signal::PresageManager, storage::JsonStorage};
 
 const TARGET_FPS: u64 = 144;
+const RECEIPT_TICK_PERIOD: u64 = 144;
 const FRAME_BUDGET: Duration = Duration::from_millis(1000 / TARGET_FPS);
+const RECEIPT_BUDGET: Duration = Duration::from_millis(RECEIPT_TICK_PERIOD * 1000 / TARGET_FPS);
 const MESSAGE_SCROLL_BACK: bool = false;
 
 #[derive(Debug, StructOpt)]
@@ -166,6 +168,18 @@ async fn run_single_threaded(relink: bool) -> anyhow::Result<()> {
     let mut last_render_at = Instant::now();
     let is_render_spawned = Arc::new(AtomicBool::new(false));
 
+    let tick_tx = tx.clone();
+    // Tick to trigger receipt sending
+    tokio::spawn(async move {
+        loop {
+            tick_tx
+                .send(Event::Tick)
+                .await
+                .expect("Cannot tick: events channel closed.");
+            tokio::time::sleep(RECEIPT_BUDGET).await;
+        }
+    });
+
     loop {
         // render
         let left_frame_budget = FRAME_BUDGET.checked_sub(last_render_at.elapsed());
@@ -191,6 +205,9 @@ async fn run_single_threaded(relink: bool) -> anyhow::Result<()> {
         }
 
         match rx.recv().await {
+            Some(Event::Tick) => {
+                let _ = app.step_receipts();
+            }
             Some(Event::Click(event)) => match event.kind {
                 MouseEventKind::Down(MouseButton::Left) => {
                     let col = event.column;

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -195,7 +195,7 @@ impl SignalManager for PresageManager {
             quote: quote_message,
             attachments: Default::default(),
             reactions: Default::default(),
-            receipt: Default::default(),
+            receipt: Receipt::Sent,
         }
     }
 
@@ -476,7 +476,7 @@ pub mod test {
                 attachments: Default::default(),
                 reactions: Default::default(),
                 // TODO make sure the message sending procedure did not fail
-                receipt: crate::app::Receipt::Sent,
+                receipt: Receipt::Sent,
             };
             self.sent_messages.borrow_mut().push(message.clone());
             println!("sent messages: {:?}", self.sent_messages.borrow());

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -292,6 +292,7 @@ fn send_receipts(app: &mut App, height: usize) {
             .skip(offset)
             .for_each(|msg| match msg.receipt {
                 Receipt::Read => (),
+                Receipt::Nothing => (), // Retro-compatibilaty
                 _ => {
                     if msg.from_id != user_id {
                         timestamps.push(msg.arrived_at);
@@ -311,8 +312,9 @@ fn send_receipts(app: &mut App, height: usize) {
         Some(c) if !c.messages.items.is_empty() => c,
         _ => return,
     };
-
-    app.send_receipts(channel, timestamps, Receipt::Read);
+    if !timestamps.is_empty() {
+        let _ = app.send_receipts(channel, timestamps, Receipt::Read);
+    }
 }
 
 fn draw_messages<B: Backend>(f: &mut Frame<B>, app: &mut App, area: Rect) {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -290,18 +290,18 @@ fn prepare_receipts(app: &mut App, height: usize) {
         .rev()
         .skip(offset)
         .for_each(|msg| match msg.receipt {
-            Receipt::Read | Receipt::Nothing | Receipt::Sent => (),
+            Receipt::Delivered | Receipt::Nothing | Receipt::Sent => (),
             Receipt::Received => {
                 if msg.from_id != user_id {
                     to_send.push((msg.from_id, msg.arrived_at));
-                    msg.receipt = Receipt::Read
+                    msg.receipt = Receipt::Delivered
                 }
             }
         });
     if !to_send.is_empty() {
         to_send
             .into_iter()
-            .for_each(|(u, t)| app.add_receipt_event(ReceiptEvent::new(u, t, Receipt::Read)))
+            .for_each(|(u, t)| app.add_receipt_event(ReceiptEvent::new(u, t, Receipt::Delivered)))
     }
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -290,9 +290,8 @@ fn prepare_receipts(app: &mut App, height: usize) {
         .rev()
         .skip(offset)
         .for_each(|msg| match msg.receipt {
-            Receipt::Read => (),
-            Receipt::Nothing => (), // Backward-compatibility
-            _ => {
+            Receipt::Read | Receipt::Nothing | Receipt::Sent => (),
+            Receipt::Received => {
                 if msg.from_id != user_id {
                     to_send.push((msg.from_id, msg.arrived_at));
                     msg.receipt = Receipt::Read


### PR DESCRIPTION
This PR should both :

- Fix #115. This issue originated in a small bug causing the client to repeatedly send empty `ReceiptMessage`s.
- Isolate the handling of these receipts. They take the form of `ReceiptEvent`s that can be created anywhere in the client and they are handled in a separate structure, stored in a set (idea from @boxdot). At regular interval (default 1 per s.; this rate can safely be increased), an event, if any, is sent. 

Technical clarification : the events are sent grouped by `Uuid` and whether they are `Delivered` or `Read`, so the number of waiting events cannot exceed `2 * (number of active conversations)`.

Shortcomings : 

- This handler does not get saved in the database. This means that closing the client while some receipt events are still waiting to get sent will result in them never getting sent at all.