### PR TITLE
Add support for downloading attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Add support for downloading attachments ([#122])
+
+[#122]: https://github.com/boxdot/gurk-rs/pull/122
+
 ## 0.2.3
 
 ### Added

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -2,13 +2,15 @@ use crate::app::{Channel, ChannelId, GroupData, Message, Receipt};
 use crate::config::{self, Config};
 use crate::util::utc_now_timestamp_msec;
 
+use anyhow::anyhow;
 use anyhow::{bail, Context as _};
 use async_trait::async_trait;
+use chrono::Utc;
 use gh_emoji::Replacer;
 use log::error;
 use presage::prelude::content::Reaction;
 use presage::prelude::proto::data_message::Quote;
-use presage::prelude::proto::ReceiptMessage;
+use presage::prelude::proto::{AttachmentPointer, ReceiptMessage};
 use presage::prelude::{
     AttachmentSpec, ContentBody, DataMessage, GroupContextV2, GroupMasterKey, SignalServers,
 };
@@ -36,6 +38,11 @@ pub trait SignalManager {
         &mut self,
         master_key_bytes: GroupMasterKeyBytes,
     ) -> anyhow::Result<ResolvedGroup>;
+
+    async fn save_attachment(
+        &mut self,
+        attachment_pointer: AttachmentPointer,
+    ) -> anyhow::Result<Attachment>;
 
     fn send_receipt(&self, sender_uuid: Uuid, timestamps: Vec<u64>, receipt: Receipt);
 
@@ -242,7 +249,7 @@ impl SignalManager for PresageManager {
         match self.manager.retrieve_profile_by_uuid(id, profile_key).await {
             Ok(profile) => Some(profile.name?.given_name),
             Err(e) => {
-                error!("failed to retreive user profile: {}", e);
+                error!("failed to retrieve user profile: {}", e);
                 None
             }
         }
@@ -279,6 +286,40 @@ impl SignalManager for PresageManager {
             profile_keys,
         })
     }
+
+    async fn save_attachment(
+        &mut self,
+        attachment_pointer: AttachmentPointer,
+    ) -> anyhow::Result<Attachment> {
+        let data_dir = dirs::data_dir()
+            .ok_or_else(|| anyhow!("could not find data directory"))?
+            .join("gurk");
+        let attachment_data = self.manager.get_attachment(&attachment_pointer).await?;
+
+        let date = Utc::now().to_rfc3339();
+        let filename = match attachment_pointer.content_type.as_ref().map(|s| s.as_str()) {
+            Some("image/jpeg") => format!("signal-{}.jpg", date),
+            Some("image/gif") => format!("signal-{}.gif", date),
+            Some("image/png") => format!("signal-{}.png", date),
+            Some(mimetype) => {
+                log::warn!("unsupported attachment mimetype: {}", mimetype);
+                format!("signal-{}", date)
+            }
+            None => {
+                format!("signal-{}", date)
+            }
+        };
+
+        let filepath = data_dir.join(filename);
+        std::fs::write(&filepath, &attachment_data)?;
+
+        Ok(Attachment {
+            id: date,
+            content_type: attachment_pointer.content_type.unwrap(),
+            filename: filepath,
+            size: attachment_pointer.size.unwrap(),
+        })
+    }
 }
 
 async fn upload_attachments(
@@ -310,7 +351,7 @@ pub struct Attachment {
     pub id: String,
     pub content_type: String,
     pub filename: PathBuf,
-    pub size: u64,
+    pub size: u32,
 }
 
 /// If `db_path` does not exist, it will be created (including parent directories).

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -297,7 +297,7 @@ impl SignalManager for PresageManager {
         let attachment_data = self.manager.get_attachment(&attachment_pointer).await?;
 
         let date = Utc::now().to_rfc3339();
-        let filename = match attachment_pointer.content_type.as_ref().map(|s| s.as_str()) {
+        let filename = match attachment_pointer.content_type.as_deref() {
             Some("image/jpeg") => format!("signal-{}.jpg", date),
             Some("image/gif") => format!("signal-{}.gif", date),
             Some("image/png") => format!("signal-{}.png", date),
@@ -515,6 +515,13 @@ pub mod test {
             _emoji: String,
             _remove: bool,
         ) {
+        }
+
+        async fn save_attachment(
+            &mut self,
+            _attachment_pointer: AttachmentPointer,
+        ) -> anyhow::Result<Attachment> {
+            bail!("mocked signal manager cannot save attachments");
         }
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -359,6 +359,7 @@ fn draw_messages<B: Backend>(f: &mut Frame<B>, app: &mut App, area: Rect) {
     let prefix = " ".repeat(prefix_width);
 
     let messages_from_offset = messages.iter().rev().skip(offset).filter_map(|msg| {
+        log::debug!("{}", msg.attachments.len());
         display_message(
             app,
             msg,
@@ -559,6 +560,21 @@ fn display_message(
                 Spans::from(res)
             }),
     );
+
+    spans.extend(msg.attachments.iter().map(|attachment| {
+        let line = attachment.filename.display().to_string();
+        let res = if add_time {
+            vec![
+                time.clone(),
+                from.clone(),
+                delimiter.clone(),
+                Span::from(line),
+            ]
+        } else {
+            vec![Span::from(line)]
+        };
+        Spans::from(res)
+    }));
 
     if spans.len() > height {
         // span is too big to be shown fully

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -542,7 +542,7 @@ fn display_message(
 
     let add_time = spans.is_empty();
     spans.extend(
-        textwrap::wrap(&text, wrap_opts)
+        textwrap::wrap(&text, &wrap_opts)
             .into_iter()
             .enumerate()
             .map(|(idx, line)| {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -421,6 +421,11 @@ fn draw_messages<B: Backend>(f: &mut Frame<B>, app: &mut App, area: Rect) {
     channel.messages.rendered.offset = offset;
 }
 
+fn display_datetime(timestamp: u64) -> String {
+    let dt = util::utc_timestamp_msec_to_local(timestamp);
+    format!("{} {:02}:{:02} ", dt.weekday(), dt.hour(), dt.minute())
+}
+
 #[allow(clippy::too_many_arguments)]
 fn display_message(
     names: &NameResolver,
@@ -430,15 +435,8 @@ fn display_message(
     height: usize,
     print_receipt: bool,
 ) -> Option<ListItem<'static>> {
-    let arrived_at = util::utc_timestamp_msec_to_local(msg.arrived_at);
-
     let time = Span::styled(
-        format!(
-            "{} {:02}:{:02} ",
-            arrived_at.weekday(),
-            arrived_at.hour(),
-            arrived_at.minute()
-        ),
+        display_datetime(msg.arrived_at),
         Style::default().fg(Color::Yellow),
     );
 
@@ -814,7 +812,10 @@ mod tests {
 
         let expected = ListItem::new(Text::from(vec![
             Spans(vec![
-                Span::styled("Sun 12:59 ", Style::default().fg(Color::Yellow)),
+                Span::styled(
+                    display_datetime(msg.arrived_at),
+                    Style::default().fg(Color::Yellow),
+                ),
                 Span::styled("boxdot", Style::default().fg(Color::Green)),
                 Span::raw(": "),
                 Span::raw("<file:///tmp/gurk/signal-2022-01-"),
@@ -843,7 +844,10 @@ mod tests {
 
         let expected = ListItem::new(Text::from(vec![
             Spans(vec![
-                Span::styled("Sun 12:59 ", Style::default().fg(Color::Yellow)),
+                Span::styled(
+                    display_datetime(msg.arrived_at),
+                    Style::default().fg(Color::Yellow),
+                ),
                 Span::styled("boxdot", Style::default().fg(Color::Green)),
                 Span::raw(": "),
                 Span::raw("Hello, World!"),


### PR DESCRIPTION
Populate the `attachments` field when receiving messages, where `filename` is the actual path stored on disk. I couldn't figure out a good way to render those paths after the messages, and I'm sure you can do it in an instant 💨 