### PR TITLE
Show qrcode in terminal instead of PNG viewer 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,25 +5,33 @@
 ### Added
 
 - Add support for downloading attachments ([#122])
+- Add release build for aarch64-unknown-musl ([#126])
+- Show qrcode in terminal instead of PNG viewer ([#127])
 
 [#122]: https://github.com/boxdot/gurk-rs/pull/122
+[#126]: https://github.com/boxdot/gurk-rs/pull/126
+[#127]: https://github.com/boxdot/gurk-rs/pull/127
 
 ## 0.2.3
 
 ### Added
 
--  Add help panel ([#107])
--  Basic multiline editing support ([#109])
+- Add help panel ([#107])
+- Basic multiline editing support ([#109])
+- Add search bar + receipt notifications ([#114])
 
 [#107]: https://github.com/boxdot/gurk-rs/pull/107
 [#109]: https://github.com/boxdot/gurk-rs/pull/109
+[#114]: https://github.com/boxdot/gurk-rs/pull/114
 
 ### Fixed
 
 - Fix linking device ([#101], [#102])
+- Fix and isolate message receipts ([#116])
 
 [#101]: https://github.com/boxdot/gurk-rs/pull/101
 [#102]: https://github.com/boxdot/gurk-rs/pull/102
+[#116]: https://github.com/boxdot/gurk-rs/pull/116
 
 ## 0.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@
 
 - Add support for downloading attachments ([#122])
 - Add release build for aarch64-unknown-musl ([#126])
-- Show qrcode in terminal instead of PNG viewer ([#127])
+- Show qrcode in terminal instead of PNG viewer ([#128])
 
 [#122]: https://github.com/boxdot/gurk-rs/pull/122
 [#126]: https://github.com/boxdot/gurk-rs/pull/126
-[#127]: https://github.com/boxdot/gurk-rs/pull/127
+[#128]: https://github.com/boxdot/gurk-rs/pull/128
 
 ## 0.2.3
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,12 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "adler32"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
-
-[[package]]
 name = "aead"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,12 +290,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
-name = "bytemuck"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9966d2ab714d0f785dbac0a0396251a35280aeb42413281617d0209ab4898435"
-
-[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,12 +380,6 @@ dependencies = [
  "unicode-width",
  "vec_map",
 ]
-
-[[package]]
-name = "color_quant"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "combine"
@@ -576,16 +558,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "deflate"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73770f8e1fe7d64df17ca66ad28994a0a623ea497fa69486e14984e715c5d174"
-dependencies = [
- "adler32",
- "byteorder",
-]
-
-[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -758,7 +730,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "crc32fast",
  "libc",
- "miniz_oxide 0.4.4",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1003,7 +975,7 @@ dependencies = [
  "log4rs",
  "mime_guess",
  "notify-rust",
- "opener 0.5.0",
+ "opener",
  "phonenumber",
  "presage",
  "regex-automata",
@@ -1222,21 +1194,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "image"
-version = "0.23.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ffcb7e7244a9bf19d35bf2883b9c080c4ced3c07a9895572178cdb8f13f6a1"
-dependencies = [
- "bytemuck",
- "byteorder",
- "color_quant",
- "num-iter",
- "num-rational",
- "num-traits",
- "png",
-]
-
-[[package]]
 name = "indexmap"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1364,7 +1321,7 @@ dependencies = [
 [[package]]
 name = "libsignal-service"
 version = "0.1.0"
-source = "git+https://github.com/whisperfish/libsignal-service-rs#bb76ca58fbb50e5064328117cca5b8b1c72db919"
+source = "git+https://github.com/whisperfish/libsignal-service-rs?rev=efd4ea86f57520d99141bb9c1c4b38a2ac646d6a#efd4ea86f57520d99141bb9c1c4b38a2ac646d6a"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1397,7 +1354,7 @@ dependencies = [
 [[package]]
 name = "libsignal-service-hyper"
 version = "0.1.0"
-source = "git+https://github.com/whisperfish/libsignal-service-rs#bb76ca58fbb50e5064328117cca5b8b1c72db919"
+source = "git+https://github.com/whisperfish/libsignal-service-rs?rev=efd4ea86f57520d99141bb9c1c4b38a2ac646d6a#efd4ea86f57520d99141bb9c1c4b38a2ac646d6a"
 dependencies = [
  "async-trait",
  "async-tungstenite",
@@ -1561,15 +1518,6 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
-dependencies = [
- "adler32",
-]
-
-[[package]]
-name = "miniz_oxide"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
@@ -1695,28 +1643,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-iter"
-version = "0.1.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1809,15 +1735,6 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
-name = "opener"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13117407ca9d0caf3a0e74f97b490a7e64c0ae3aa90a8b7085544d0c37b6f3ae"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "opener"
@@ -1998,18 +1915,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "png"
-version = "0.16.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3287920cb847dee3de33d301c463fba14dda99db24214ddf93f83d3021f4c6"
-dependencies = [
- "bitflags 1.2.1",
- "crc32fast",
- "deflate",
- "miniz_oxide 0.3.7",
-]
-
-[[package]]
 name = "poksho"
 version = "0.7.0"
 source = "git+https://github.com/signalapp/poksho.git?tag=v0.7.0#8bb8c61c18e7bbe93c094ed91be52b9f96c1c5cd"
@@ -2052,19 +1957,17 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "presage"
-version = "0.1.0"
-source = "git+https://github.com/whisperfish/presage.git?branch=main#4b3457fd95902950be00e2cba318af2d5425e888"
+version = "0.2.0"
+source = "git+https://github.com/whisperfish/presage.git?branch=main#ee1aa4163393c0e53e80c021ca59e2c78b2ea807"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
  "futures",
  "hex",
- "image",
  "libsignal-service",
  "libsignal-service-hyper",
  "log",
- "opener 0.4.1",
- "qrcode",
+ "qr2term",
  "rand 0.7.3",
  "serde",
  "serde_json",
@@ -2253,13 +2156,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "qr2term"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9634478e874d4153c52d10d6f8660ad1b17be5d5a48aa7286f3d52fd2c9b7c34"
+dependencies = [
+ "crossterm",
+ "qrcode",
+]
+
+[[package]]
 name = "qrcode"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16d2f1455f3630c6e5107b4f2b94e74d76dea80736de0981fd27644216cff57f"
 dependencies = [
  "checked_int_cast",
- "image",
 ]
 
 [[package]]


### PR DESCRIPTION
This was implemented in presage. We just upgrade the dependency.