### PR TITLE
Add cursor tracking and multiline input navigation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,6 @@ env:
   RUSTFLAGS: "-D warnings"
   RUSTUP_MAX_RETRIES: 10
   FETCH_DEPTH: 0
-  NIGHTLY_VERSION: nightly-2021-06-08
 
 jobs:
   rustfmt:
@@ -114,7 +113,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env.NIGHTLY_VERSION }}
+          toolchain: stable
           target: aarch64-unknown-linux-gnu
           profile: minimal
           override: true
@@ -196,7 +195,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env.NIGHTLY_VERSION }}
+          toolchain: stable
           target: aarch64-apple-darwin
           profile: minimal
           override: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,6 @@ env:
   RUSTFLAGS: "-D warnings"
   RUSTUP_MAX_RETRIES: 10
   FETCH_DEPTH: 0 # pull in the tags for the version string
-  NIGHTLY_VERSION: nightly-2021-06-08
 
 jobs:
   dist-changelog:
@@ -101,7 +100,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env.NIGHTLY_VERSION }}
+          toolchain: stable
           target: aarch64-unknown-linux-gnu
           profile: minimal
           override: true
@@ -189,7 +188,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env.NIGHTLY_VERSION }}
+          toolchain: stable
           target: aarch64-apple-darwin
           profile: minimal
           override: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,24 @@
 ### Added
 
 - Add support for downloading attachments ([#122])
-- Add release build for aarch64-unknown-musl ([#126])
+- Add release build for `aarch64-unknown-musl` ([#126])
 - Show qrcode in terminal instead of PNG viewer ([#128])
+- Document key bindings and packages ([#130])
+
+## Changed
+
+- Add cursor tracking and multiline input navigation ([#131])
+
+### Fixed
+
+- Bug: infinite loop while skkiping words on input box ([#129], [#131])
 
 [#122]: https://github.com/boxdot/gurk-rs/pull/122
 [#126]: https://github.com/boxdot/gurk-rs/pull/126
 [#128]: https://github.com/boxdot/gurk-rs/pull/128
+[#129]: https://github.com/boxdot/gurk-rs/pull/129
+[#130]: https://github.com/boxdot/gurk-rs/pull/130
+[#131]: https://github.com/boxdot/gurk-rs/pull/131
 
 ## 0.2.3
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -674,6 +674,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "error-chain"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -978,6 +988,8 @@ dependencies = [
  "opener",
  "phonenumber",
  "presage",
+ "quickcheck",
+ "quickcheck_macros",
  "regex-automata",
  "scopeguard",
  "serde",
@@ -2181,6 +2193,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cc440ee4802a86e357165021e3e255a9143724da31db1e2ea540214c96a0f82"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "quickcheck"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
+dependencies = [
+ "env_logger",
+ "log",
+ "rand 0.8.4",
+]
+
+[[package]]
+name = "quickcheck_macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b22a693222d716a9587786f37ac3f6b4faedb5b80c23914e7303ff5a1d8016e9"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.9",
+ "syn 1.0.73",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "gurk"
 description = "Signal messenger client for terminal"
 version = "0.2.3"
 authors = ["boxdot <d@zerovolt.org>"]
-edition = "2018"
+edition = "2021"
 keywords = ["signal", "tui"]
 repository = "https://github.com/boxdot/gurk-rs"
 license = "AGPL-3.0-only"
@@ -56,6 +56,8 @@ uuid = "0.8.2"
 whoami = "1.1.2"
 
 [dev-dependencies]
+quickcheck = "1.0.3"
+quickcheck_macros = "1.0.0"
 tempfile = "3.2.0"
 uuid = { version = "0.8.2", features = ["v4"] }
 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ libraries that are not available on crates.io.
 * [x] Reply functionality to a single message.
 * [ ] Mouse navigation (works for channels, missing for the messages list).
 * [ ] Search of messages/chats. Add quick switch between chats by name.
-* [X] Multiline messages; the `Enter` key sends the message.
-* [ ] Viewing/sending of attachments (sending works).
+* [x] Multiline messages; the `Enter` key sends the message, `Alt+Enter` switches modes.
+* [x] Viewing/sending of attachments.
 * [ ] Support for blocked contacts/groups.
 * [x] Reactions with emojis.
 * [x] Open URL in selected message.
@@ -67,24 +67,28 @@ libraries that are not available on crates.io.
 * App navigation
   * `f1` Toggle help panel.
   * `alt+tab` Switch between message input box and search bar.
-* Message edition.
+* Message input
   * `tab` Send emoji from input line as reaction on selected message.
-  * `alt+enter` Add newline.
+  * `alt+enter` Switch between multi-line and singl-line input modes.
+  * `alt+left`, `alt+right` Jump to previous/next word.
   * `ctrl+w / ctrl+backspace / alt+backspace` Delete last word.
   * `enter` *when input box empty* Open URL from selected message.
   * `enter` *otherwise* Send message.
+* Multi-line message input
+  * `enter` New line
+  * `ctrl+j / Up` Previous line
+  * `ctrl+k / Down` Next line
 * Cursor
   * `alt+f / alt+Right / ctrl+Right` Move forward one word.
   * `alt+b / alt+Left / ctrl+Left` Move backward one word.
-  * `ctrl+a / home` Move cursor to the beginning of the text.
-  * `ctrl+e / end` Move cursor the the end of the text.
+  * `ctrl+a / Home` Move cursor to the beginning of the line.
+  * `ctrl+e / End` Move cursor the the end of the line.
 * Message/channel selection
   * `Esc` Reset message selection.
   * `alt+Up / PgUp` Select previous message.
   * `alt+Down / PgDown` Select next message.
   * `ctrl+j / Up` Select previous channel.
   * `ctrl+k / Down` Select next channel.
-
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ libraries that are not available on crates.io.
   * `alt+enter` Switch between multi-line and singl-line input modes.
   * `alt+left`, `alt+right` Jump to previous/next word.
   * `ctrl+w / ctrl+backspace / alt+backspace` Delete last word.
-  * `enter` *when input box empty* Open URL from selected message.
+  * `enter` *when input box empty in single-line mode* Open URL from selected message.
   * `enter` *otherwise* Send message.
 * Multi-line message input
   * `enter` New line

--- a/src/app.rs
+++ b/src/app.rs
@@ -1663,8 +1663,6 @@ mod tests {
         assert_eq!(app.data.channels.items[0].unread_messages, 0);
 
         assert_eq!(app.get_input().data, "");
-        // assert_eq!(app.get_input().input_cursor, 0);
-        // assert_eq!(app.get_input().input_cursor_chars, 0);
     }
 
     #[test]
@@ -1674,8 +1672,6 @@ mod tests {
         for c in input.chars() {
             app.get_input().put_char(c);
         }
-        // assert_eq!(app.get_input().input_cursor, 4);
-        // assert_eq!(app.get_input().input_cursor_chars, 1);
 
         app.send_input(0).unwrap();
 
@@ -1684,8 +1680,6 @@ mod tests {
         assert_eq!(sent[0].message.as_ref().unwrap(), input);
 
         assert_eq!(app.get_input().data, "");
-        // assert_eq!(app.get_input().input_cursor, 0);
-        // assert_eq!(app.get_input().input_cursor_chars, 0);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -619,11 +619,11 @@ impl App {
     pub fn on_key(&mut self, key: KeyEvent) -> anyhow::Result<()> {
         match key.code {
             KeyCode::Char('\r') => self.get_input().put_char('\n'),
-            KeyCode::Enter if key.modifiers.contains(KeyModifiers::ALT) => {
+            KeyCode::Enter if key.modifiers.contains(KeyModifiers::ALT) && !self.is_searching => {
                 self.data.is_multiline_input = !self.data.is_multiline_input;
             }
-            KeyCode::Enter if self.data.is_multiline_input => {
-                self.data.input.new_line();
+            KeyCode::Enter if self.data.is_multiline_input && !self.is_searching => {
+                self.get_input().new_line();
             }
             KeyCode::Enter if !self.get_input().data.is_empty() && !self.is_searching => {
                 if let Some(idx) = self.data.channels.state.selected() {

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1,0 +1,529 @@
+use itertools::Itertools;
+use unicode_width::UnicodeWidthChar;
+
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+pub struct Cursor {
+    /// Position of the character as byte index
+    pub idx: usize,
+    /// Position vertically
+    pub line: usize,
+    /// Position horizontally
+    pub col: usize,
+    col_wanted: Option<usize>,
+}
+
+impl Cursor {
+    #[cfg(test)]
+    pub fn new(idx: usize, line: usize, col: usize) -> Self {
+        Self {
+            idx,
+            line,
+            col,
+            ..Default::default()
+        }
+    }
+
+    #[cfg(test)]
+    pub fn begin() -> Self {
+        Default::default()
+    }
+
+    pub fn end(text: &str) -> Self {
+        let idx = snap_to_char(text, text.len());
+        let (line, col) = calc_line_column(text, idx);
+        Self {
+            idx,
+            line,
+            col,
+            col_wanted: None,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn at(text: &str, idx: usize) -> Self {
+        let idx = snap_to_char(text, idx);
+        let (line, col) = calc_line_column(text, idx);
+        Self {
+            idx,
+            line,
+            col,
+            col_wanted: None,
+        }
+    }
+
+    pub fn put(&mut self, c: char, text: &mut String) {
+        text.insert(self.idx, c);
+        if c == '\n' {
+            self.line += 1;
+            self.col = 0;
+            self.idx += 1;
+        } else {
+            self.col += c.width().unwrap_or(0);
+            self.idx += c.len_utf8();
+        }
+        self.col_wanted = None;
+    }
+
+    pub fn new_line(&mut self, text: &mut String) {
+        self.put('\n', text);
+    }
+
+    pub fn move_left(&mut self, text: &str) {
+        let mut char_indices = text[..self.idx].char_indices();
+        if let Some((idx, c)) = char_indices.next_back() {
+            if c == '\n' {
+                self.line -= 1;
+                self.col = char_indices
+                    .rev()
+                    .take_while(|&(_, c)| c != '\n')
+                    .map(|(_, c)| c.width().unwrap_or(0))
+                    .sum();
+            } else {
+                self.col -= c.width().unwrap_or(0);
+            }
+            self.idx = idx;
+            self.col_wanted = None;
+        }
+    }
+
+    pub fn move_right(&mut self, text: &str) {
+        let mut char_indices = text[self.idx..]
+            .char_indices()
+            .map(|(idx, c)| (idx + self.idx, c));
+        if let Some((_idx, c)) = char_indices.next() {
+            if c == '\n' {
+                self.line += 1;
+                self.col = 0;
+            } else {
+                self.col += c.width().unwrap_or(0);
+            }
+            self.idx = char_indices
+                .next()
+                .map(|(idx, _c)| idx)
+                .unwrap_or_else(|| text.len());
+            self.col_wanted = None;
+        }
+    }
+
+    pub fn delete_backward(&mut self, text: &mut String) {
+        let mut char_indices = text[..self.idx].char_indices();
+        if let Some((idx, c)) = char_indices.next_back() {
+            if c == '\n' {
+                self.line -= 1;
+                self.col = char_indices
+                    .rev()
+                    .take_while(|&(_, c)| c != '\n')
+                    .map(|(_, c)| c.width().unwrap_or(0))
+                    .sum();
+            } else {
+                self.col -= c.width().unwrap_or(0);
+            }
+            self.idx = idx;
+            text.remove(idx);
+        }
+    }
+
+    pub fn delete_word_backward(&mut self, text: &mut String) {
+        let end = self.idx;
+        self.move_word_left(text);
+        text.replace_range(self.idx..end, "");
+    }
+
+    pub fn move_line_down(&mut self, text: &str) {
+        let offset = self.idx;
+        let mut char_indices = text[offset..]
+            .char_indices()
+            .map(|(idx, c)| (idx + offset, c))
+            .skip_while(|&(_, c)| c != '\n')
+            .map(|(idx, _)| idx);
+        let end_line = char_indices.next();
+        if let Some(start) = char_indices.next() {
+            self.line += 1;
+            let prev_col = *self.col_wanted.get_or_insert(self.col);
+
+            let end = text[start..]
+                .char_indices()
+                .find(|&(_, c)| c == '\n')
+                .map(|(idx, _)| start + idx)
+                .unwrap_or_else(|| text.len());
+
+            let (idx, col) = text[start..end]
+                .char_indices()
+                .take(prev_col + 1)
+                .scan(0, |prev_width, (idx, c)| {
+                    let col = *prev_width;
+                    *prev_width += c.width().unwrap_or(0);
+                    Some((start + idx, col))
+                })
+                .last()
+                .unwrap_or((start, 0));
+
+            self.col = col;
+            self.idx = idx;
+        } else if let Some(idx) = end_line {
+            self.col = text[..idx]
+                .chars()
+                .rev()
+                .take_while(|&c| c != '\n')
+                .map(|c| c.width().unwrap_or(0))
+                .sum();
+            self.idx = idx;
+        } else {
+            self.col = text
+                .chars()
+                .rev()
+                .take_while(|&c| c != '\n')
+                .map(|c| c.width().unwrap_or(0))
+                .sum();
+            self.idx = text.len();
+        }
+    }
+
+    pub fn move_line_up(&mut self, text: &str) {
+        if let Some((end, _)) = text[..self.idx]
+            .char_indices()
+            .rev()
+            .find(|&(_, c)| c == '\n')
+        {
+            self.line -= 1;
+            let prev_col = *self.col_wanted.get_or_insert(self.col);
+
+            let start = text[..end]
+                .char_indices()
+                .rev()
+                .find(|&(_, c)| c == '\n')
+                .map(|(idx, _)| idx + 1)
+                .unwrap_or(0);
+
+            let (idx, col) = text[start..end]
+                .char_indices()
+                .take(prev_col + 1)
+                .scan(0, |prev_width, (idx, c)| {
+                    let col = *prev_width;
+                    *prev_width += c.width().unwrap_or(0);
+                    Some((start + idx, col))
+                })
+                .last()
+                .unwrap_or((start, 0));
+
+            self.col = col;
+            self.idx = idx;
+        } else {
+            self.col = 0;
+            self.idx = 0;
+        }
+    }
+
+    pub fn move_word_left(&mut self, text: &str) {
+        let mut chars = text[..self.idx].chars().rev().peekable();
+
+        while let Some(c) = chars.peek() {
+            if !c.is_whitespace() {
+                break;
+            }
+            self.move_left(text);
+            chars.next();
+        }
+
+        while let Some(c) = chars.peek() {
+            if c.is_whitespace() {
+                break;
+            }
+            self.move_left(text);
+            chars.next();
+        }
+    }
+
+    pub fn move_word_right(&mut self, text: &str) {
+        let mut chars = text[self.idx..].chars().peekable();
+
+        while let Some(c) = chars.peek() {
+            if c.is_whitespace() {
+                break;
+            }
+            self.move_right(text);
+            chars.next();
+        }
+
+        while let Some(c) = chars.peek() {
+            if !c.is_whitespace() {
+                break;
+            }
+            self.move_right(text);
+            chars.next();
+        }
+    }
+
+    pub fn start_of_line(&mut self, text: &str) {
+        if let Some((idx, col, c)) = text[..self.idx]
+            .char_indices()
+            .rev()
+            .scan(0, |prev_width, (idx, c)| {
+                let col = *prev_width;
+                *prev_width += c.width().unwrap_or(0);
+                Some((idx, col, c))
+            })
+            .find(|&(_, _, c)| c == '\n')
+        {
+            self.idx = idx;
+            self.col -= col;
+            self.line -= 1;
+            if c == '\n' {
+                self.move_right(text);
+            }
+        } else {
+            self.idx = 0;
+            self.col = 0;
+        }
+    }
+
+    pub fn end_of_line(&mut self, text: &str) {
+        let offset = self.idx;
+        if let Some((idx, col, c)) = text[self.idx..]
+            .char_indices()
+            .scan(0, |prev_width, (idx, c)| {
+                let col = *prev_width;
+                *prev_width += c.width().unwrap_or(0);
+                Some((offset + idx, col, c))
+            })
+            .find_or_last(|&(_, _, c)| c == '\n')
+        {
+            self.idx = idx;
+            self.col += col;
+            if c != '\n' {
+                // end of text
+                self.move_right(text);
+            }
+        }
+    }
+
+    pub fn delete_suffix(&mut self, text: &mut String) {
+        let end = text[self.idx..]
+            .char_indices()
+            .find(|&(_, c)| c == '\n')
+            .map(&|(idx, _)| idx)
+            .unwrap_or_else(|| text.len());
+        if self.idx == end && end < text.len() {
+            text.remove(end);
+        } else {
+            text.replace_range(self.idx..end, "");
+        }
+    }
+}
+
+/// Snap the byte index `idx` to a char boundary in `s`.
+///
+/// The snapping is always done to left starting at `idx`.
+fn snap_to_char(s: &str, mut idx: usize) -> usize {
+    if idx >= s.len() {
+        s.len()
+    } else {
+        while !s.is_char_boundary(idx) {
+            if let Some(new_idx) = idx.checked_sub(1) {
+                idx = new_idx
+            } else {
+                break;
+            }
+        }
+        idx
+    }
+}
+
+fn calc_line_column(s: &str, idx: usize) -> (usize, usize) {
+    let mut col = 0;
+    let mut line = 0;
+
+    for c in s[0..idx].chars().rev() {
+        if c == '\n' {
+            line += 1;
+        }
+        if line == 0 {
+            col += 1;
+        }
+    }
+
+    (line, col)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    use quickcheck::{Arbitrary, Gen};
+    use quickcheck_macros::quickcheck;
+
+    #[test]
+    fn test_cursor_empty() {
+        let cur = Cursor::end("");
+        assert_eq!(cur, Cursor::begin());
+    }
+
+    #[test]
+    fn test_cursor_one_line() {
+        let cur = Cursor::end("Hello, world!");
+        assert_eq!(cur, Cursor::new(13, 0, 13));
+    }
+
+    #[test]
+    fn test_cursor_new_line() {
+        let cur = Cursor::end("\n\n");
+        assert_eq!(cur, Cursor::new(2, 2, 0));
+    }
+
+    #[test]
+    fn test_cursor_multiple_lines() {
+        let cur = Cursor::end("Hello\n\nWorld");
+        assert_eq!(cur, Cursor::new(12, 2, 5));
+    }
+
+    #[test]
+    fn test_cursor_at() {
+        let text = "Hello\nWorld\n\n".to_string();
+        assert_eq!(Cursor::at(&text, 0), Cursor::begin());
+        assert_eq!(Cursor::at(&text, 0), Cursor::new(0, 0, 0));
+        assert_eq!(Cursor::at(&text, 1), Cursor::new(1, 0, 1));
+        assert_eq!(Cursor::at(&text, 5), Cursor::new(5, 0, 5));
+        assert_eq!(Cursor::at(&text, 6), Cursor::new(6, 1, 0));
+        assert_eq!(Cursor::at(&text, 6), Cursor::new(6, 1, 0));
+        assert_eq!(Cursor::at(&text, 11), Cursor::new(11, 1, 5));
+        assert_eq!(Cursor::at(&text, 12), Cursor::new(12, 2, 0));
+        assert_eq!(Cursor::at(&text, 13), Cursor::new(13, 3, 0));
+        assert_eq!(Cursor::at(&text, 100), Cursor::new(13, 3, 0));
+    }
+
+    #[test]
+    fn test_move_word_left_right() {
+        let text = "Hello\n  new🌍\n\nWorld";
+        let mut cursor = Cursor::begin();
+
+        let stops = vec![
+            Cursor::new(0, 0, 0),
+            Cursor::new(8, 1, 2),
+            Cursor::new(17, 3, 0),
+            Cursor::new(22, 3, 5),
+        ];
+
+        for stop in &stops {
+            assert_eq!(stop, &cursor);
+            cursor.move_word_right(text);
+        }
+
+        for stop in stops.iter().rev() {
+            assert_eq!(stop, &cursor);
+            cursor.move_word_left(text);
+        }
+    }
+
+    #[test]
+    fn test_delete_suffix() {
+        let mut text = "Hello\n  new🌍\n\nWorld".to_string();
+        let mut cursor = Cursor::begin();
+
+        cursor.delete_suffix(&mut text);
+        assert_eq!(cursor, Cursor::new(0, 0, 0));
+        assert_eq!(text, "\n  new🌍\n\nWorld");
+
+        cursor.delete_suffix(&mut text);
+        assert_eq!(cursor, Cursor::new(0, 0, 0));
+        assert_eq!(text, "  new🌍\n\nWorld");
+
+        cursor.delete_suffix(&mut text);
+        assert_eq!(cursor, Cursor::new(0, 0, 0));
+        assert_eq!(text, "\n\nWorld");
+
+        cursor.delete_suffix(&mut text);
+        assert_eq!(cursor, Cursor::new(0, 0, 0));
+        assert_eq!(text, "\nWorld");
+
+        cursor.delete_suffix(&mut text);
+        assert_eq!(cursor, Cursor::new(0, 0, 0));
+        assert_eq!(text, "World");
+
+        cursor.delete_suffix(&mut text);
+        assert_eq!(cursor, Cursor::new(0, 0, 0));
+        assert_eq!(text, "");
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    enum Operation {
+        Left,
+        Right,
+        Down,
+        Up,
+        Put(char),
+        DeleteBackward,
+    }
+
+    impl Arbitrary for Operation {
+        fn arbitrary(g: &mut Gen) -> Self {
+            use Operation::*;
+
+            let mut c = char::arbitrary(g);
+            while c.width().unwrap_or(0) == 0 {
+                c = char::arbitrary(g);
+            }
+
+            *g.choose(&[Left, Right, Up, Down, Put(c), DeleteBackward])
+                .unwrap()
+        }
+    }
+
+    #[quickcheck]
+    fn test_random_operations_sequence(operations: Vec<Operation>) -> bool {
+        let mut text = "Hello\nnew🌍\n\nWorld".to_string();
+
+        let calc_index_matrix = |text: &str| {
+            let mut res: HashMap<(usize, usize), usize> = Default::default();
+
+            let mut line = 0;
+            let mut col = 0;
+
+            for (idx, c) in text.char_indices() {
+                res.insert((line, col), idx);
+                if c == '\n' {
+                    line += 1;
+                    col = 0;
+                }
+                col += c.width().unwrap_or(0);
+            }
+            res
+        };
+
+        let mut cursor = Cursor::begin();
+        let mut index_matrix = calc_index_matrix(&text);
+
+        for op in operations {
+            let is_last = cursor.idx == text.len();
+            let is_entry = cursor.idx < text.len()
+                && index_matrix.get(&(cursor.line, cursor.col)) == Some(&cursor.idx);
+            if !(is_last || is_entry) {
+                println!("is_last = {is_last}");
+                println!("is_entry = {is_entry}");
+                println!("{text:?}");
+                println!("{index_matrix:?}");
+                println!("cursor = {cursor:?}");
+                println!("op = {op:?}");
+                return false;
+            }
+
+            match op {
+                Operation::Left => cursor.move_left(&text),
+                Operation::Right => cursor.move_right(&text),
+                Operation::Down => cursor.move_line_down(&text),
+                Operation::Up => cursor.move_line_up(&text),
+                Operation::Put(c) => {
+                    cursor.put(c, &mut text);
+                    index_matrix = calc_index_matrix(&text);
+                }
+                Operation::DeleteBackward => {
+                    cursor.delete_backward(&mut text);
+                    index_matrix = calc_index_matrix(&text);
+                }
+            }
+        }
+
+        true
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 
 mod app;
 mod config;
+mod cursor;
 mod shortcuts;
 mod signal;
 mod storage;
@@ -249,6 +250,10 @@ async fn run_single_threaded(relink: bool) -> anyhow::Result<()> {
                     // Toggle help panel
                     app.toggle_help();
                 }
+                // KeyCode::Char('p') => {
+                //     info!("{event:?}");
+                //     info!("this will command selection");
+                // }
                 KeyCode::Char('c') if event.modifiers.contains(KeyModifiers::CONTROL) => {
                     break;
                 }
@@ -263,7 +268,6 @@ async fn run_single_threaded(relink: bool) -> anyhow::Result<()> {
                     }
                 }
                 KeyCode::Up if event.modifiers.contains(KeyModifiers::ALT) => app.on_pgup(),
-                KeyCode::Up => app.select_previous_channel(),
                 KeyCode::Right => {
                     if event
                         .modifiers
@@ -275,7 +279,6 @@ async fn run_single_threaded(relink: bool) -> anyhow::Result<()> {
                     }
                 }
                 KeyCode::Down if event.modifiers.contains(KeyModifiers::ALT) => app.on_pgdn(),
-                KeyCode::Down => app.select_next_channel(),
                 KeyCode::PageUp => app.on_pgup(),
                 KeyCode::PageDown => app.on_pgdn(),
                 KeyCode::Tab if event.modifiers.contains(KeyModifiers::ALT) => app.toggle_search(),
@@ -285,20 +288,36 @@ async fn run_single_threaded(relink: bool) -> anyhow::Result<()> {
                 KeyCode::Char('b') if event.modifiers.contains(KeyModifiers::ALT) => {
                     app.get_input().move_back_word();
                 }
-                KeyCode::Char('a') if event.modifiers.contains(KeyModifiers::CONTROL) => {
-                    app.get_input().on_home();
-                }
-                KeyCode::Char('e') if event.modifiers.contains(KeyModifiers::CONTROL) => {
-                    app.get_input().on_end();
-                }
                 KeyCode::Char('w') if event.modifiers.contains(KeyModifiers::CONTROL) => {
                     app.get_input().on_delete_word();
                 }
+                KeyCode::Down => {
+                    if app.data.is_multiline_input {
+                        app.data.input.move_line_down();
+                    } else {
+                        app.select_next_channel();
+                    }
+                }
                 KeyCode::Char('j') if event.modifiers.contains(KeyModifiers::CONTROL) => {
-                    app.select_next_channel();
+                    if app.data.is_multiline_input {
+                        app.data.input.move_line_down();
+                    } else {
+                        app.select_next_channel();
+                    }
+                }
+                KeyCode::Up => {
+                    if app.data.is_multiline_input {
+                        app.data.input.move_line_up();
+                    } else {
+                        app.select_previous_channel();
+                    }
                 }
                 KeyCode::Char('k') if event.modifiers.contains(KeyModifiers::CONTROL) => {
-                    app.select_previous_channel();
+                    if app.data.is_multiline_input {
+                        app.data.input.move_line_up();
+                    } else {
+                        app.select_previous_channel();
+                    }
                 }
                 KeyCode::Backspace
                     if event

--- a/src/main.rs
+++ b/src/main.rs
@@ -250,10 +250,6 @@ async fn run_single_threaded(relink: bool) -> anyhow::Result<()> {
                     // Toggle help panel
                     app.toggle_help();
                 }
-                // KeyCode::Char('p') => {
-                //     info!("{event:?}");
-                //     info!("this will command selection");
-                // }
                 KeyCode::Char('c') if event.modifiers.contains(KeyModifiers::CONTROL) => {
                     break;
                 }

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -16,7 +16,7 @@ pub static SHORTCUTS: &[ShortCut] = &[
     },
     ShortCut {
         event: "alt+enter",
-        description: "Add newline.",
+        description: "Switch between single-line and multi-line modes.",
     },
     ShortCut {
         event: "alt+tab",
@@ -31,8 +31,12 @@ pub static SHORTCUTS: &[ShortCut] = &[
         description: "Open URL from selected message.",
     },
     ShortCut {
-        event: "enter, otherwise",
+        event: "enter, single-line mode",
         description: "Send message.",
+    },
+    ShortCut {
+        event: "enter, multi-line mode",
+        description: "New line message.",
     },
     ShortCut {
         event: "alt+f / alt+Right / ctrl+Right",
@@ -63,11 +67,19 @@ pub static SHORTCUTS: &[ShortCut] = &[
         description: "Select next message.",
     },
     ShortCut {
-        event: "ctrl+j / Up",
+        event: "ctrl+j / Up, single-line mode",
         description: "Select previous channel.",
     },
     ShortCut {
-        event: "ctrl+k / Down",
+        event: "ctrl+j / Up, multi-line mode",
+        description: "Previous line",
+    },
+    ShortCut {
+        event: "ctrl+k / Down, single-line mode",
         description: "Select next channel.",
+    },
+    ShortCut {
+        event: "ctrl+k / Down, multi-line mode",
+        description: "Next line",
     },
 ];

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -27,7 +27,7 @@ pub static SHORTCUTS: &[ShortCut] = &[
         description: "Delete last word.",
     },
     ShortCut {
-        event: "enter, when input box empty",
+        event: "enter, when input box empty in single-line mode",
         description: "Open URL from selected message.",
     },
     ShortCut {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,8 +1,8 @@
 use crate::app::AppData;
+use crate::cursor::Cursor;
 
 use anyhow::Context;
 use log::info;
-use unicode_width::UnicodeWidthStr;
 use uuid::Uuid;
 
 use std::fs::File;
@@ -100,8 +100,7 @@ impl JsonStorage {
         info!("loading app data from: {}", data_path.as_ref().display());
         let f = BufReader::new(File::open(data_path)?);
         let mut data: AppData = serde_json::from_reader(f)?;
-        data.input.input_cursor = data.input.data.len();
-        data.input.input_cursor_chars = data.input.data.width();
+        data.input.cursor = Cursor::end(&data.input.data);
         Ok(data)
     }
 }
@@ -139,6 +138,7 @@ pub mod test {
 mod tests {
     use crate::{
         app::{BoxData, Channel, ChannelId, TypingSet},
+        cursor::Cursor,
         util::FilteredStatefulList,
     };
 
@@ -150,16 +150,8 @@ mod tests {
         let user_id = Uuid::new_v4();
         let user_name = "Tyler Durden".to_string();
         let app_data = AppData {
-            input: BoxData {
-                data: "".to_string(),
-                input_cursor: 0,
-                input_cursor_chars: 0,
-            },
-            search_box: BoxData {
-                data: "".to_string(),
-                input_cursor: 0,
-                input_cursor_chars: 0,
-            },
+            input: BoxData::empty(),
+            search_box: BoxData::empty(),
             names: [(user_id, user_name.clone())].iter().cloned().collect(),
             ..Default::default()
         };
@@ -201,16 +193,8 @@ mod tests {
         let user_id = Uuid::new_v4();
         let user_name = "Tyler Durden".to_string();
         let app_data = AppData {
-            input: BoxData {
-                data: "".to_string(),
-                input_cursor: 0,
-                input_cursor_chars: 0,
-            },
-            search_box: BoxData {
-                data: "".to_string(),
-                input_cursor: 0,
-                input_cursor_chars: 0,
-            },
+            input: BoxData::empty(),
+            search_box: BoxData::empty(),
             names: [(user_id, user_name.clone())].iter().cloned().collect(),
             ..Default::default()
         };
@@ -235,14 +219,13 @@ mod tests {
         let app_data = AppData {
             input: BoxData {
                 data: "some input".to_string(),
-                input_cursor: 10,
-                input_cursor_chars: 10,
+                cursor: Cursor::end("some input"),
             },
             search_box: BoxData {
                 data: "some search".to_string(),
-                input_cursor: 10,
-                input_cursor_chars: 10,
+                cursor: Cursor::end("some search"),
             },
+            is_multiline_input: false,
             names: [(user_id, user_name.clone())].iter().cloned().collect(),
             channels: FilteredStatefulList::_with_items(vec![Channel {
                 id: ChannelId::User(user_id),


### PR DESCRIPTION
Cursor tracks a byte position in a text, and additionally a column
and line. It implements navigation of left/right,line up/down,
beginning/end of a line, and basic word operation. Also it supports
unicode and characters of width > 1.

Message input now supports switching between the single line and
multi-line modes via Alt+Enter. Previously, Alt+Enter inserted a new
line. Having a special mode for multi-line is more powerful, since it
allows navigation between lines with the same shortcuts as navigation
in channels and messages. And it allows pasting multi-line text.

CI is switched to use the stable aarch64 rustc compiler. Nightly was
required due to signal-client using the armv8 feature in aes which
was only available on nightly.

Fixes #129