### PR TITLE
Return upon unknown group

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1142,7 +1142,7 @@ impl App {
                         false
                     }
                 })
-                .unwrap();
+                .ok_or(())?;
             if let TypingSet::GroupTyping(ref mut hash_set) = group.typing {
                 match action {
                     TypingAction::Started => {


### PR DESCRIPTION
Should fix #132. It is possible to receive typing notifications from groups that have not been added to `gurk`'db, resulting in a crash when trying to find the corresponding group. Now we simply ignore these orphan notifications.