### PR TITLE
Fix publish CI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,16 @@
 [alias]
 xtask = "run --package xtask --"
+
+[env]
+CC_aarch64_unknown_linux_musl = "clang"
+AR_aarch64_unknown_linux_musl = "llvm-ar"
+
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"
+
+[target.aarch64-unknown-linux-musl]
+rustflags = ["-Clink-self-contained=yes"]
+linker = "rust-lld"
+
+[target.x86_64-unknown-linux-musl]
+rustflags = ["-Clink-self-contained=yes"]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,14 +5,13 @@ name: ci
 env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
-  RUSTFLAGS: "-D warnings"
   RUSTUP_MAX_RETRIES: 10
   FETCH_DEPTH: 0
 
 jobs:
   rustfmt:
     name: rustfmt
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -24,6 +23,7 @@ jobs:
           toolchain: stable
           profile: minimal
           components: rustfmt
+          override: true
       - name: Check format
         uses: actions-rs/cargo@v1
         with:
@@ -32,7 +32,7 @@ jobs:
 
   clippy:
     name: clippy
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -44,6 +44,7 @@ jobs:
           toolchain: stable
           profile: minimal
           components: clippy
+          override: true
       - name: Clippy
         uses: actions-rs/cargo@v1
         with:
@@ -51,7 +52,7 @@ jobs:
 
   build-test-x86_64-unknown-linux-gnu:
     name: build and test (x86_64-unknown-linux-gnu)
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -78,9 +79,6 @@ jobs:
       image: rust:alpine
       volumes:
         - /usr/local/cargo/registry
-    env:
-      # For some reason `-crt-static` is not working for clang without lld
-      RUSTFLAGS: "-C link-arg=-fuse-ld=lld -C target-feature=-crt-static"
     steps:
       - name: Install dependencies
         run: apk add --no-cache musl-dev lld protoc
@@ -102,9 +100,7 @@ jobs:
 
   build-aarch64-unknown-linux-gnu:
     name: build (aarch64-unknown-linux-gnu)
-    runs-on: ubuntu-18.04
-    env:
-      CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -132,12 +128,9 @@ jobs:
       image: rust:alpine
       volumes:
         - /usr/local/cargo/registry
-    env:
-      # For some reason `-crt-static` is not working for clang without lld
-      RUSTFLAGS: "-C link-arg=-fuse-ld=lld -C target-feature=-crt-static"
     steps:
       - name: Install dependencies
-        run: apk add --no-cache musl-dev lld protoc
+        run: apk add --no-cache musl-dev clang lld llvm protoc
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
@@ -148,6 +141,7 @@ jobs:
           toolchain: stable
           profile: minimal
           target: aarch64-unknown-linux-musl
+          override: true
       - name: Build
         uses: actions-rs/cargo@v1
         with:
@@ -171,6 +165,7 @@ jobs:
         with:
           toolchain: stable
           profile: minimal
+          override: true
       - name: Build
         uses: actions-rs/cargo@v1
         with:
@@ -200,7 +195,7 @@ jobs:
           profile: minimal
           override: true
       - name: Build
-        run: |
-          export SDKROOT=$(xcrun -sdk macosx11.0 --show-sdk-path)
-          export MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.0 --show-sdk-platform-version)
-          cargo build --target aarch64-apple-darwin
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --target aarch64-apple-darwin

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,14 +7,13 @@ on:
 env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
-  RUSTFLAGS: "-D warnings"
   RUSTUP_MAX_RETRIES: 10
   FETCH_DEPTH: 0 # pull in the tags for the version string
 
 jobs:
   dist-changelog:
     name: dist (changelog)
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -25,6 +24,7 @@ jobs:
         with:
           toolchain: stable
           profile: minimal
+          override: true
       - name: Generate checklog
         run: cargo xtask changelog
       - name: Upload artifacts
@@ -35,7 +35,7 @@ jobs:
 
   dist-x86_64-unknown-linux-gnu:
     name: dist (x86_64-unknown-linux-gnu)
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -46,6 +46,7 @@ jobs:
         with:
           toolchain: stable
           profile: minimal
+          override: true
       - name: Dist
         run: cargo xtask dist
       - name: Upload artifacts
@@ -62,9 +63,7 @@ jobs:
       volumes:
         - /usr/local/cargo/registry
     env:
-      # For some reason `-crt-static` is not working for clang without lld
       GURK_TARGET: x86_64-unknown-linux-musl
-      RUSTFLAGS: "-C link-arg=-fuse-ld=lld -C target-feature=-crt-static"
     steps:
       - name: Install dependencies
         run: apk add --no-cache musl-dev clang lld protoc
@@ -78,6 +77,7 @@ jobs:
           toolchain: stable
           profile: minimal
           target: x86_64-unknown-linux-musl
+          override: true
       - name: Dist
         run: cargo xtask dist
       - name: Upload artifacts
@@ -88,10 +88,9 @@ jobs:
 
   dist-aarch64-unknown-linux-gnu:
     name: dist (aarch64-unknown-linux-gnu)
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     env:
       GURK_TARGET: aarch64-unknown-linux-gnu
-      CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -116,18 +115,16 @@ jobs:
 
   dist-aarch64-unknown-linux-musl:
     name: dist (aarch64-unknown-linux-musl)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
       image: rust:alpine
       volumes:
         - /usr/local/cargo/registry
     env:
-      # For some reason `-crt-static` is not working for clang without lld
       GURK_TARGET: aarch64-unknown-linux-musl
-      RUSTFLAGS: "-C link-arg=-fuse-ld=lld -C target-feature=-crt-static"
     steps:
       - name: Install dependencies
-        run: apk add --no-cache musl-dev clang lld protoc
+        run: apk add --no-cache musl-dev clang lld llvm protoc
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
@@ -138,6 +135,7 @@ jobs:
           toolchain: stable
           profile: minimal
           target: aarch64-unknown-linux-musl
+          override: true
       - name: Dist
         run: cargo xtask dist
       - name: Upload artifacts
@@ -151,7 +149,7 @@ jobs:
     runs-on: macos-latest
     env:
       GURK_TARGET: x86_64-apple-darwin
-      SELECT_XCODE: /Applications/Xcode_12.2.app
+      SELECT_XCODE: /Applications/Xcode_13.2.app
     steps:
       - name: Select XCode version
         run: sudo xcode-select -s "${SELECT_XCODE}"
@@ -164,6 +162,7 @@ jobs:
         with:
           toolchain: stable
           profile: minimal
+          override: true
       - name: Dist
         run: cargo xtask dist
       - name: Upload artifacts
@@ -177,7 +176,7 @@ jobs:
     runs-on: macos-latest
     env:
       GURK_TARGET: aarch64-apple-darwin
-      SELECT_XCODE: /Applications/Xcode_12.2.app
+      SELECT_XCODE: /Applications/Xcode_13.2.app
     steps:
       - name: Select XCode version
         run: sudo xcode-select -s "${SELECT_XCODE}"
@@ -193,10 +192,7 @@ jobs:
           profile: minimal
           override: true
       - name: Dist
-        run: |
-          export SDKROOT=$(xcrun -sdk macosx11.0 --show-sdk-path)
-          export MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.0 --show-sdk-platform-version)
-          cargo xtask dist
+        run: cargo xtask dist
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -243,10 +239,8 @@ jobs:
         with:
           name: dist-aarch64-unknown-linux-musl
           path: dist
-
       - run: ls -al
         working-directory: dist
-
       - name: Release
         uses: softprops/action-gh-release@v1
         env:


### PR DESCRIPTION
Use latest ubuntu and macos xcode. Also move all environment vars
into .cargo/config.toml. Since RUSTFLAGS env var overrides the
rust flags set in .cargo/config.toml, we removed RUSTFLAGS="-D
warnings".