### PR TITLE
Fix receiving direct messages sent from another device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 ### Changed
 
+- Fixed receiving direct messages sent from another device
 - Replace log4rs with tracing ([#158], [#160])
-
-[#158]: https://github.com/boxdot/gurk-rs/pull/158
-[#160]: https://github.com/boxdot/gurk-rs/pull/160
+  [#158]: https://github.com/boxdot/gurk-rs/pull/158
+  [#160]: https://github.com/boxdot/gurk-rs/pull/160
 
 ## 0.2.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@
 
 - Fixed receiving direct messages sent from another device
 - Replace log4rs with tracing ([#158], [#160])
-  [#158]: https://github.com/boxdot/gurk-rs/pull/158
-  [#160]: https://github.com/boxdot/gurk-rs/pull/160
+
+[#158]: https://github.com/boxdot/gurk-rs/pull/158
+[#160]: https://github.com/boxdot/gurk-rs/pull/160
 
 ## 0.2.4
 

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -284,7 +284,12 @@ impl SignalManager for PresageManager {
                 Err(_) => continue,
             };
             members.push(uuid);
-            profile_keys.push(member.profile_key.try_into().map_err(|_| anyhow!("malformed profile key"))?);
+            profile_keys.push(
+                member
+                    .profile_key
+                    .try_into()
+                    .map_err(|_| anyhow!("malformed profile key"))?,
+            );
         }
 
         let name = decrypted_group.title;


### PR DESCRIPTION
Sync messages for direct messages don't contain E164 phone numbers anymore (as they should).

Note: this is extracted from #161 to avoid unrelated changes.