### PR TITLE
Improve name resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,18 @@
 
 ### Changed
 
-- Fixed receiving direct messages sent from another device
 - Replace log4rs with tracing ([#158], [#160])
+- Display date only once per day ([#164])
+
+### Fixed
+
+- Fixed receiving direct messages sent from another device ([#162])
+- Improve name resolution ([#167])
 
 [#158]: https://github.com/boxdot/gurk-rs/pull/158
 [#160]: https://github.com/boxdot/gurk-rs/pull/160
+[#162]: https://github.com/boxdot/gurk-rs/pull/162
+[#167]: https://github.com/boxdot/gurk-rs/pull/167
 
 ## 0.2.4
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1396,7 +1396,7 @@ dependencies = [
 [[package]]
 name = "libsignal-service"
 version = "0.1.0"
-source = "git+https://github.com/whisperfish/libsignal-service-rs?rev=efd4ea86f57520d99141bb9c1c4b38a2ac646d6a#efd4ea86f57520d99141bb9c1c4b38a2ac646d6a"
+source = "git+https://github.com/boxdot/libsignal-service-rs?rev=8be91da2#8be91da26eb6393fc222f476381da3ecdda8a5df"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1429,7 +1429,7 @@ dependencies = [
 [[package]]
 name = "libsignal-service-hyper"
 version = "0.1.0"
-source = "git+https://github.com/whisperfish/libsignal-service-rs?rev=efd4ea86f57520d99141bb9c1c4b38a2ac646d6a#efd4ea86f57520d99141bb9c1c4b38a2ac646d6a"
+source = "git+https://github.com/boxdot/libsignal-service-rs?rev=8be91da2#8be91da26eb6393fc222f476381da3ecdda8a5df"
 dependencies = [
  "async-trait",
  "async-tungstenite",
@@ -2001,7 +2001,7 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 [[package]]
 name = "presage"
 version = "0.2.0"
-source = "git+https://github.com/whisperfish/presage.git?rev=8fcfb65#8fcfb6510c3a3ae4aeb9bafb535091d5b6ef1824"
+source = "git+https://github.com/boxdot/presage.git?rev=f908e8f#f908e8ff89e0532831dcee82e22b6cc0a35bf9a6"
 dependencies = [
  "async-trait",
  "base64 0.12.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ debug = 0
 lto = "thin"
 
 [dependencies]
-presage = { git = "https://github.com/whisperfish/presage.git", rev = "8fcfb65" }
+presage = { git = "https://github.com/boxdot/presage.git", rev = "f908e8f" }
 
 anyhow = "1.0.40"
 async-trait = "0.1.51"


### PR DESCRIPTION
Name resolution from profile (via signal service) was broken due to
fetching of unversioned profile in libsignal-service. We patched the
library. The patch is not yet upstreamed and used from the main branch
due to the presage issue [62].

[62]: https://github.com/whisperfish/presage/issues/62