### PR TITLE
Disappearing messages tracking PR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2495,18 +2495,18 @@ checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
 
 [[package]]
 name = "serde"
-version = "1.0.144"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
+checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.144"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
+checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/app.rs
+++ b/src/app.rs
@@ -1354,9 +1354,12 @@ mod tests {
                 attachments: Default::default(),
                 reactions: Default::default(),
                 receipt: Default::default(),
+                to_skip: false,
+                expire_timestamp: ExpireTimer::from_delay_now(None),
             }]),
             unread_messages: 1,
             typing: TypingSet::GroupTyping(HashSet::new()),
+            expire_timer: Some(42),
         });
         app.data.channels.state.select(Some(0));
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -330,7 +330,7 @@ impl App {
     }
 
     pub async fn on_message(&mut self, content: Content) -> anyhow::Result<()> {
-        // tracing::debug!("incoming: {:#?}", content);
+        tracing::info!("incoming: {:#?}", content);
         let user_id = self.user_id;
 
         let (channel_idx, message) = match (content.metadata, content.body) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -513,16 +513,13 @@ impl App {
                     let master_key = master_key
                         .try_into()
                         .map_err(|_| anyhow!("invalid group master key"))?;
-                    
 
-                    self
-                        .ensure_group_channel_exists(master_key, revision)
+                    self.ensure_group_channel_exists(master_key, revision)
                         .await
                         .context("failed to create group channel")?
                 } else {
                     // In a direct message channel
                     let name = self.name_by_id(uuid);
-                    
 
                     self.ensure_contact_channel_exists(uuid, &name).await
                 };

--- a/src/app.rs
+++ b/src/app.rs
@@ -929,6 +929,7 @@ impl App {
                 messages: StatefulList::with_items(Vec::new()),
                 unread_messages: 0,
                 typing: TypingSet::GroupTyping(HashSet::new()),
+                expire_timer: None,
             });
             Ok(self.data.channels.items.len() - 1)
         }
@@ -1001,6 +1002,7 @@ impl App {
                 messages: StatefulList::with_items(Vec::new()),
                 unread_messages: 0,
                 typing: TypingSet::SingleTyping(false),
+                expire_timer: None,
             });
             self.data.channels.items.len() - 1
         }
@@ -1020,6 +1022,11 @@ impl App {
             }
             channel_idx
         } else {
+            let expire_timer = self
+                .signal_manager
+                .contact_by_id(uuid)
+                .unwrap_or(None)
+                .map(|c| c.expire_timer.clone());
             self.data.channels.items.push(Channel {
                 id: uuid.into(),
                 name: name.to_string(),
@@ -1027,6 +1034,7 @@ impl App {
                 messages: StatefulList::with_items(Vec::new()),
                 unread_messages: 0,
                 typing: TypingSet::SingleTyping(false),
+                expire_timer,
             });
             self.data.channels.items.len() - 1
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -922,6 +922,7 @@ impl App {
             )
             .await;
 
+            // FIXME Add message expiration for groups
             self.data.channels.items.push(Channel {
                 id,
                 name,
@@ -995,6 +996,7 @@ impl App {
         {
             channel_idx
         } else {
+            // FIXME check whether own channel has disappearing messages enabled
             self.data.channels.items.push(Channel {
                 id: user_id.into(),
                 name: self.config.user.name.clone(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -911,6 +911,7 @@ impl App {
                 name,
                 group_data,
                 profile_keys,
+                expire_timer
             } = self.signal_manager.resolve_group(master_key).await?;
 
             self.ensure_users_are_known(
@@ -922,7 +923,6 @@ impl App {
             )
             .await;
 
-            // FIXME Add message expiration for groups
             self.data.channels.items.push(Channel {
                 id,
                 name,
@@ -930,7 +930,7 @@ impl App {
                 messages: StatefulList::with_items(Vec::new()),
                 unread_messages: 0,
                 typing: TypingSet::GroupTyping(HashSet::new()),
-                expire_timer: None,
+                expire_timer,
             });
             Ok(self.data.channels.items.len() - 1)
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -363,7 +363,7 @@ impl App {
                 add_emoji_from_sticker(&mut body, sticker);
 
                 let expiration =
-                    ExpireTimer::from_delay_s_opt(self.get_channel(channel_idx).expire_timer);
+                    ExpireTimer::from_delay_now(self.get_channel(channel_idx).expire_timer);
 
                 let message = Message::new(user_id, body, timestamp, attachments, expiration);
                 (channel_idx, message)
@@ -394,6 +394,7 @@ impl App {
                                     expire_timer,
                                     ..
                                 }),
+                            expiration_start_timestamp,
                             ..
                         }),
                     ..
@@ -426,7 +427,8 @@ impl App {
                     bail!("message without a group context and without a destination uuid");
                 };
 
-                let expire_timestamp = ExpireTimer::from_delay_s_opt(expire_timer);
+                let expire_timestamp =
+                    ExpireTimer::from_delay_and_start(expire_timer, expiration_start_timestamp);
 
                 add_emoji_from_sticker(&mut body, sticker);
                 let quote = quote
@@ -611,7 +613,7 @@ impl App {
                     );
                     channel.expire_timer = expire_timer;
                 }
-                let expire_timestamp = ExpireTimer::from_delay_s_opt(expire_timer);
+                let expire_timestamp = ExpireTimer::from_delay_now(expire_timer);
 
                 let quote = quote
                     .and_then(|q| Message::from_quote(q, expire_timestamp))

--- a/src/data.rs
+++ b/src/data.rs
@@ -151,9 +151,10 @@ impl Channel {
             .iter()
             .fold(0, |acc, m| acc + if m.to_skip { 0 } else { 1 });
         let mut seq = serializer.serialize_seq(Some(to_write_amount))?;
-        for e in messages.items {
-            seq.serialize_element(&e)?;
-        }
+        // Only serialize unskipped messages
+        messages.items.iter().filter(|m| !m.to_skip).for_each(|m| {
+            seq.serialize_element(m);
+        });
         seq.end()
     }
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -294,7 +294,12 @@ impl SerSkip for Message {
 pub struct ExpireTimer(Option<u64>);
 
 impl ExpireTimer {
-    pub fn from_delay_s_opt(delay_s: Option<u32>) -> Self {
-        ExpireTimer(delay_s.map(|d| d as u64 * 1_000_000 + utc_now_timestamp_msec()))
+    pub fn from_delay_now(delay_s: Option<u32>) -> Self {
+        ExpireTimer(delay_s.map(|d| d as u64 * 1_000 + utc_now_timestamp_msec()))
+    }
+    pub fn from_delay_and_start(delay_s: Option<u32>, start: Option<u64>) -> Self {
+        ExpireTimer(
+            delay_s.map(|d| d as u64 * 1_000 + start.unwrap_or_else(utc_now_timestamp_msec)),
+        )
     }
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -239,6 +239,10 @@ pub struct Message {
 }
 
 impl Message {
+    // sdsd
+    // FIXME Expiration start timestamp is not always [`now()`]
+    // On the case of a sync'ed message, the start timestamp is sooner in the past.
+    // See https://github.com/signalapp/Signal-Desktop/blob/190cd9408b67de68a74096f37bff5b2dc9dd3674/protos/SignalService.proto#L404
     pub fn new(
         from_id: Uuid,
         message: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -227,10 +227,9 @@ async fn run_single_threaded(relink: bool) -> anyhow::Result<()> {
         match rx.recv().await {
             Some(Event::ReceiptTick) => {
                 let _ = app.step_receipts();
-                // TODO Handle expired messages
             }
             Some(Event::ExpireTick) => {
-                // Check for expired messages
+                // TODO Handle expired messages
             }
             Some(Event::Click(event)) => match event.kind {
                 MouseEventKind::Down(MouseButton::Left) => {

--- a/src/signal/impl.rs
+++ b/src/signal/impl.rs
@@ -54,6 +54,8 @@ impl SignalManager for PresageManager {
         let master_key = GroupMasterKey::new(master_key_bytes);
         let decrypted_group = self.manager.get_group_v2(master_key).await?;
 
+        let expire_timer = decrypted_group.disappearing_messages_timer.map(|t| t.duration);
+
         let mut members = Vec::with_capacity(decrypted_group.members.len());
         let mut profile_keys = Vec::with_capacity(decrypted_group.members.len());
         for member in decrypted_group.members {
@@ -72,6 +74,7 @@ impl SignalManager for PresageManager {
             name,
             group_data,
             profile_keys,
+            expire_timer,
         })
     }
 

--- a/src/signal/impl.rs
+++ b/src/signal/impl.rs
@@ -54,7 +54,9 @@ impl SignalManager for PresageManager {
         let master_key = GroupMasterKey::new(master_key_bytes);
         let decrypted_group = self.manager.get_group_v2(master_key).await?;
 
-        let expire_timer = decrypted_group.disappearing_messages_timer.map(|t| t.duration);
+        let expire_timer = decrypted_group
+            .disappearing_messages_timer
+            .map(|t| t.duration);
 
         let mut members = Vec::with_capacity(decrypted_group.members.len());
         let mut profile_keys = Vec::with_capacity(decrypted_group.members.len());
@@ -150,7 +152,7 @@ impl SignalManager for PresageManager {
             ..Default::default()
         });
 
-        let expire_timer = channel.expire_timer.clone();
+        let expire_timer = channel.expire_timer;
         let quote_message = quote
             .clone()
             .and_then(|q| Message::from_quote(q, expire_timer))
@@ -160,6 +162,7 @@ impl SignalManager for PresageManager {
             body: Some(message.clone()),
             timestamp: Some(timestamp),
             quote,
+            expire_timer,
             ..Default::default()
         };
 

--- a/src/signal/impl.rs
+++ b/src/signal/impl.rs
@@ -153,9 +153,10 @@ impl SignalManager for PresageManager {
         });
 
         let expire_timer = channel.expire_timer;
+        let id = channel.counter.next();
         let quote_message = quote
             .clone()
-            .and_then(|q| Message::from_quote(q, ExpireTimer::from_delay_now(expire_timer)))
+            .and_then(|q| Message::from_quote(q, ExpireTimer::from_delay_now(expire_timer), id))
             .map(Box::new);
 
         let mut data_message = DataMessage {
@@ -226,6 +227,7 @@ impl SignalManager for PresageManager {
             receipt: Receipt::Sent,
             to_skip: false,
             expire_timestamp: ExpireTimer::from_delay_now(expire_timer),
+            id: Some(id),
         }
     }
 

--- a/src/signal/impl.rs
+++ b/src/signal/impl.rs
@@ -147,7 +147,7 @@ impl SignalManager for PresageManager {
             ..Default::default()
         });
 
-        let expire_timer = channel.expire_timestamp.clone();
+        let expire_timer = channel.expire_timer.clone();
         let quote_message = quote
             .clone()
             .and_then(|q| Message::from_quote(q, expire_timer))

--- a/src/signal/impl.rs
+++ b/src/signal/impl.rs
@@ -155,7 +155,7 @@ impl SignalManager for PresageManager {
         let expire_timer = channel.expire_timer;
         let quote_message = quote
             .clone()
-            .and_then(|q| Message::from_quote(q, ExpireTimer::from_delay_s_opt(expire_timer)))
+            .and_then(|q| Message::from_quote(q, ExpireTimer::from_delay_now(expire_timer)))
             .map(Box::new);
 
         let mut data_message = DataMessage {
@@ -225,7 +225,7 @@ impl SignalManager for PresageManager {
             reactions: Default::default(),
             receipt: Receipt::Sent,
             to_skip: false,
-            expire_timestamp: ExpireTimer::from_delay_s_opt(expire_timer),
+            expire_timestamp: ExpireTimer::from_delay_now(expire_timer),
         }
     }
 

--- a/src/signal/impl.rs
+++ b/src/signal/impl.rs
@@ -155,7 +155,7 @@ impl SignalManager for PresageManager {
         let expire_timer = channel.expire_timer;
         let quote_message = quote
             .clone()
-            .and_then(|q| Message::from_quote(q, expire_timer))
+            .and_then(|q| Message::from_quote(q, ExpireTimer::from_delay_s_opt(expire_timer)))
             .map(Box::new);
 
         let mut data_message = DataMessage {

--- a/src/signal/manager.rs
+++ b/src/signal/manager.rs
@@ -63,6 +63,7 @@ pub struct ResolvedGroup {
     pub name: String,
     pub group_data: GroupData,
     pub profile_keys: Vec<ProfileKey>,
+    pub expire_timer: Option<u32>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/signal/test.rs
+++ b/src/signal/test.rs
@@ -70,8 +70,9 @@ impl SignalManager for SignalManagerMock {
             text: message.message.clone(),
             ..Default::default()
         });
+        let id = _channel.counter.next();
         let quote_message = quote
-            .and_then(|q| Message::from_quote(q, ExpireTimer::from_delay_now(None)))
+            .and_then(|q| Message::from_quote(q, ExpireTimer::from_delay_now(None), id))
             .map(Box::new);
         let message = Message {
             from_id: self.user_id(),
@@ -84,6 +85,7 @@ impl SignalManager for SignalManagerMock {
             receipt: Receipt::Sent,
             to_skip: false,
             expire_timestamp: ExpireTimer::from_delay_now(None),
+            id: Some(id),
         };
         self.sent_messages.borrow_mut().push(message.clone());
         println!("sent messages: {:?}", self.sent_messages.borrow());

--- a/src/signal/test.rs
+++ b/src/signal/test.rs
@@ -70,7 +70,9 @@ impl SignalManager for SignalManagerMock {
             text: message.message.clone(),
             ..Default::default()
         });
-        let quote_message = quote.and_then(Message::from_quote).map(Box::new);
+        let quote_message = quote
+            .and_then(|q| Message::from_quote(q, None))
+            .map(Box::new);
         let message = Message {
             from_id: self.user_id(),
             message: Some(message),
@@ -80,6 +82,8 @@ impl SignalManager for SignalManagerMock {
             reactions: Default::default(),
             // TODO make sure the message sending procedure did not fail
             receipt: Receipt::Sent,
+            to_skip: false,
+            expire_timestamp: None,
         };
         self.sent_messages.borrow_mut().push(message.clone());
         println!("sent messages: {:?}", self.sent_messages.borrow());

--- a/src/signal/test.rs
+++ b/src/signal/test.rs
@@ -10,7 +10,7 @@ use presage::prelude::{AttachmentSpec, Contact, Content};
 use tokio_stream::Stream;
 use uuid::Uuid;
 
-use crate::data::{Channel, Message};
+use crate::data::{Channel, ExpireTimer, Message};
 use crate::receipt::Receipt;
 use crate::util::utc_now_timestamp_msec;
 
@@ -71,7 +71,7 @@ impl SignalManager for SignalManagerMock {
             ..Default::default()
         });
         let quote_message = quote
-            .and_then(|q| Message::from_quote(q, None))
+            .and_then(|q| Message::from_quote(q, ExpireTimer::from_delay_now(None)))
             .map(Box::new);
         let message = Message {
             from_id: self.user_id(),
@@ -83,7 +83,7 @@ impl SignalManager for SignalManagerMock {
             // TODO make sure the message sending procedure did not fail
             receipt: Receipt::Sent,
             to_skip: false,
-            expire_timestamp: None,
+            expire_timestamp: ExpireTimer::from_delay_now(None),
         };
         self.sent_messages.borrow_mut().push(message.clone());
         println!("sent messages: {:?}", self.sent_messages.borrow());

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -124,7 +124,7 @@ pub mod test {
 #[cfg(test)]
 mod tests {
     use crate::{
-        data::{Channel, ChannelId, TypingSet},
+        data::{Channel, ChannelId, MessageCounter, TypingSet},
         util::FilteredStatefulList,
     };
 
@@ -190,6 +190,7 @@ mod tests {
                 unread_messages: 0,
                 typing: TypingSet::SingleTyping(false),
                 expire_timer: Some(42),
+                counter: MessageCounter::new(),
             }]),
             contacts_sync_request_at: None,
         };

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -189,6 +189,7 @@ mod tests {
                 messages: Default::default(),
                 unread_messages: 0,
                 typing: TypingSet::SingleTyping(false),
+                expire_timer: Some(42),
             }]),
             contacts_sync_request_at: None,
         };

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -301,6 +301,7 @@ fn draw_messages<B: Backend>(f: &mut Frame<B>, app: &mut App, area: Rect) {
         messages
             .iter()
             .rev()
+            .filter(|m| !m.to_skip)
             .skip(offset)
             .map(|msg| msg.arrived_at)
             .next()
@@ -311,6 +312,8 @@ fn draw_messages<B: Backend>(f: &mut Frame<B>, app: &mut App, area: Rect) {
     let messages_from_offset = messages
         .iter()
         .rev()
+        // INFO do not display skipped (i.e. expired) messages
+        .filter(|m| !m.to_skip)
         .skip(offset)
         .flat_map(|msg| {
             let date_division = display_date_line(msg.arrived_at, &mut previous_msg_day, width);

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -710,6 +710,7 @@ mod tests {
             receipt: Receipt::Sent,
             expire_timestamp: ExpireTimer::from_delay_now(Some(42)),
             to_skip: true,
+            id: None,
         }
     }
 

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -675,7 +675,7 @@ fn displayed_quote(names: &NameResolver, quote: &Message) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use crate::signal::Attachment;
+    use crate::{data::ExpireTimer, signal::Attachment};
 
     use super::*;
 
@@ -708,6 +708,8 @@ mod tests {
             attachments: vec![],
             reactions: vec![],
             receipt: Receipt::Sent,
+            expire_timestamp: ExpireTimer::from_delay_now(Some(42)),
+            to_skip: true,
         }
     }
 

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -359,10 +359,11 @@ fn draw_messages<B: Backend>(f: &mut Frame<B>, app: &mut App, area: Rect) {
         items.insert(unread_messages, ListItem::new(Span::from(new_message_line)));
     }
 
+    // TEMP show the expire timer of the current channel
     let title: String = if let Some(writing_people) = writing_people {
-        format!("Messages {}", writing_people)
+        format!("Messages {}{:?}", writing_people, channel.expire_timer)
     } else {
-        "Messages".to_string()
+        format!("Messages {:?}", channel.expire_timer)
     };
 
     let list = List::new(items)

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,7 +8,7 @@ use crate::data::Channel;
 use crate::MESSAGE_SCROLL_BACK;
 
 /// Trait for selectable element
-/// Used in [`StatefulList`] in ordre to be able to 
+/// Used in [`StatefulList`] in ordre to be able to
 /// skip some elements at serialization
 pub trait SerSkip {
     fn skip(&self) -> bool;
@@ -55,7 +55,7 @@ pub struct Rendered {
     pub offset: usize,
 }
 
-impl<T : SerSkip> Default for StatefulList<T> {
+impl<T: SerSkip> Default for StatefulList<T> {
     fn default() -> Self {
         Self {
             state: Default::default(),

--- a/xtask/src/changelog.rs
+++ b/xtask/src/changelog.rs
@@ -36,7 +36,7 @@ fn get_version() -> Result<Version> {
 }
 
 fn extract_section(changelog: &str, version: Version) -> Result<&str> {
-    let parser = Parser::new(&changelog);
+    let parser = Parser::new(changelog);
     let h2 = parser.into_offset_iter().filter_map(|(event, range)| {
         if let Event::Start(Tag::Heading(2)) = event {
             Some(range)


### PR DESCRIPTION
Addresses #79 
Non-exhaustive list of things to implement to fully support the disappearing messages feature:

- [X] Retrieve timer information from channel. **Direct message channels not tested**
- [X] Send message with the correct timer policy
- [ ] Remove message locally when expired
- [ ] Add some UI indication. **There is a simple P-o-C (timer indicated besides the channel's name).**

## My thoughts

### Local deletion

Instead of deleting a message in-memory upon it expiring, I suggest to simply mark it as "expired", which will result in the UI not displaying it and the serializer not including it in the save file. This is already implemented, see the field `Message.to_skip`. 

Keeping the message in-memory alleviates the need for costly and kinda ugly deletion of elements in the `Vec` holding the messages, while still ensuring that expired messages get deleted from the saved database.

### UI

The UI should show a small indicator on every message giving a rough estimation of the remaining time, like in the official clients. Also showing the channel's timer policy can be a nice feature.

### Policy synchronization

For now only done in a very simple way. There might be instances where a change is not handled by the current implementation.