### PR TITLE
Add notifications config toggling system notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Add notifications config toggling system notifications
+- Add notifications config toggling system notifications ([#188], [#192])
 
 ### Changed
 
@@ -15,8 +15,10 @@
 -  Use maintenance fixed branch of presage with updated root CA ([#189], [#190])
 
 [#182]: https://github.com/boxdot/gurk-rs/pull/182
+[#188]: https://github.com/boxdot/gurk-rs/pull/188
 [#189]: https://github.com/boxdot/gurk-rs/pull/189
 [#190]: https://github.com/boxdot/gurk-rs/pull/190
+[#192]: https://github.com/boxdot/gurk-rs/pull/192
 
 ## 0.2.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased (0.3.0-dev)
 
+### Added
+
+- Add notifications config toggling system notifications
+
 ### Changed
 
 - Upgrade presage (this will force relinking the device, due to incompatible changes) ([#182])

--- a/src/app.rs
+++ b/src/app.rs
@@ -1071,8 +1071,10 @@ impl App {
     }
 
     fn notify(&self, summary: &str, text: &str) {
-        if let Err(e) = Notification::new().summary(summary).body(text).show() {
-            error!("failed to send notification: {}", e);
+        if self.config.notifications {
+            if let Err(e) = Notification::new().summary(summary).body(text).show() {
+                error!("failed to send notification: {}", e);
+            }
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,9 @@ pub struct Config {
     /// Whether to show receipts (sent, delivered, read) information next to your user name in UI
     #[serde(default = "default_true")]
     pub show_receipts: bool,
+    /// Whether to show system notifications on incoming messages
+    #[serde(default = "default_true")]
+    pub notifications: bool,
     /// User configuration
     pub user: User,
 }
@@ -39,6 +42,7 @@ impl Config {
             signal_db_path: default_signal_db_path(),
             first_name_only: false,
             show_receipts: true,
+            notifications: true,
         }
     }
 


### PR DESCRIPTION
In gurk's `config.toml` add

```toml
notifications = false  # default value is true
```