### PR TITLE
Add benchmark to measure on_message time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /xtask/Cargo.lock
 gurk.log
 Session.vim
+messages.raw.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,9 +244,9 @@ checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "bincode"
@@ -339,6 +345,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,12 +385,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+dependencies = [
+ "bitflags",
+ "clap_lex 0.2.4",
+ "indexmap",
+ "textwrap 0.16.0",
 ]
 
 [[package]]
@@ -390,7 +441,7 @@ dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
- "clap_lex",
+ "clap_lex 0.3.0",
  "once_cell",
  "strsim",
  "termcolor",
@@ -407,6 +458,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -471,12 +531,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
+dependencies = [
+ "anes",
+ "atty",
+ "cast",
+ "ciborium",
+ "clap 3.2.23",
+ "criterion-plot",
+ "futures",
+ "itertools 0.10.3",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.3",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
  "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
@@ -996,8 +1105,10 @@ version = "0.3.0-dev"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64 0.13.1",
  "chrono",
- "clap",
+ "clap 4.0.18",
+ "criterion",
  "crossterm 0.19.0",
  "derivative",
  "dirs 3.0.2",
@@ -1012,6 +1123,7 @@ dependencies = [
  "opener",
  "phonenumber",
  "presage",
+ "prost 0.10.4",
  "qr2term",
  "quickcheck",
  "quickcheck_macros",
@@ -1020,7 +1132,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "textwrap",
+ "textwrap 0.14.2",
  "tokio",
  "tokio-stream",
  "toml",
@@ -1034,6 +1146,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1045,7 +1163,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.13.1",
  "bitflags",
  "bytes",
  "headers-core",
@@ -1365,7 +1483,7 @@ dependencies = [
  "aes",
  "aes-gcm",
  "async-trait",
- "base64 0.13.0",
+ "base64 0.13.1",
  "bincode",
  "block-modes",
  "bytes",
@@ -1397,7 +1515,7 @@ source = "git+https://github.com/whisperfish/libsignal-service-rs?rev=8666ba56f4
 dependencies = [
  "async-trait",
  "async-tungstenite",
- "base64 0.13.0",
+ "base64 0.13.1",
  "bytes",
  "futures",
  "headers",
@@ -1743,6 +1861,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d11de466f4a3006fe8a5e7ec84e93b79c70cb992ae0aa0eb631ad2df8abfe2"
 
 [[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1943,6 +2067,34 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "plotters"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2538b639e642295546c50fcd545198c9d64ee2a38620a628724a3b266d5fbf97"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "poksho"
@@ -2326,6 +2478,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2437,7 +2613,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -2446,7 +2622,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -2454,6 +2630,15 @@ name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -2841,6 +3026,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+
+[[package]]
 name = "thiserror"
 version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2889,6 +3080,16 @@ dependencies = [
  "itoa",
  "libc",
  "num_threads",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3089,7 +3290,7 @@ version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.13.1",
  "byteorder",
  "bytes",
  "http",
@@ -3239,6 +3440,17 @@ name = "waker-fn"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,9 +244,9 @@ checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "base64"
-version = "0.13.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bincode"
@@ -1105,7 +1105,7 @@ version = "0.3.0-dev"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64 0.13.1",
+ "base64 0.13.0",
  "chrono",
  "clap 4.0.18",
  "criterion",
@@ -1163,7 +1163,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.13.0",
  "bitflags",
  "bytes",
  "headers-core",
@@ -1483,7 +1483,7 @@ dependencies = [
  "aes",
  "aes-gcm",
  "async-trait",
- "base64 0.13.1",
+ "base64 0.13.0",
  "bincode",
  "block-modes",
  "bytes",
@@ -1515,7 +1515,7 @@ source = "git+https://github.com/whisperfish/libsignal-service-rs?rev=8666ba56f4
 dependencies = [
  "async-trait",
  "async-tungstenite",
- "base64 0.13.1",
+ "base64 0.13.0",
  "bytes",
  "futures",
  "headers",
@@ -2613,7 +2613,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.13.0",
 ]
 
 [[package]]
@@ -2622,7 +2622,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.13.0",
 ]
 
 [[package]]
@@ -3290,7 +3290,7 @@ version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.13.0",
  "byteorder",
  "bytes",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ tokio-stream = "0.1.5"
 toml = "0.5.8"
 tui = { version = "0.15.0", default-features = false, features = ["crossterm"] }
 unicode-width = "0.1.8"
-uuid = "1.2"
+uuid = { version = "1.2", features = ["v4"] }
 whoami = "1.1.2"
 tracing = "0.1.35"
 tracing-appender = "0.2.2"
@@ -57,12 +57,18 @@ tracing-subscriber = "0.3.11"
 futures-channel = "0.3.24"
 qr2term = "0.3.0"
 clap = { version = "4.0.18", features = ["derive"] }
+prost = "0.10.0"
+base64 = "0.13.1"
 
 [dev-dependencies]
 quickcheck = "1.0.3"
 quickcheck_macros = "1.0.0"
 tempfile = "3.2.0"
-uuid = { version = "1.2", features = ["v4"] }
+criterion = { version = "0.4", features = ["async_tokio"] }
+
+[[bench]]
+name = "app"
+harness = false
 
 # [patch."https://github.com/whisperfish/presage.git"]
 # presage = { path = "../presage" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ base64 = "0.13.1"
 quickcheck = "1.0.3"
 quickcheck_macros = "1.0.0"
 tempfile = "3.2.0"
-criterion = { version = "0.4", features = ["async_tokio"] }
+criterion = { version = "0.4", features = ["async_tokio", "html_reports"] }
 
 [[bench]]
 name = "app"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ opt-level = 3
 debug = 0
 lto = "thin"
 
+[features]
+dev = ["prost", "base64"]
+
 [dependencies]
 presage = { git = "https://github.com/whisperfish/presage", rev = "f84d958", default-features = false, features = ["sled-config-store"] }
 
@@ -57,8 +60,10 @@ tracing-subscriber = "0.3.11"
 futures-channel = "0.3.24"
 qr2term = "0.3.0"
 clap = { version = "4.0.18", features = ["derive"] }
-prost = "0.10.0"
-base64 = "0.13.1"
+
+# dev feature dependencies
+prost = { version = "0.10.0", optional = true }
+base64 = { version = "0.13.0", optional = true }
 
 [dev-dependencies]
 quickcheck = "1.0.3"

--- a/benches/app.rs
+++ b/benches/app.rs
@@ -1,6 +1,6 @@
 use std::io::BufReader;
 
-use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use gurk::app::App;
 use gurk::config::{Config, User};
 use gurk::data::{AppData, Channel, ChannelId, GroupData, Message, TypingSet};
@@ -10,6 +10,7 @@ use gurk::signal::GroupMasterKeyBytes;
 use gurk::storage::Storage;
 use gurk::util::StatefulList;
 use presage::prelude::Content;
+use tracing::info;
 use uuid::Uuid;
 
 pub struct InMemoryStorage {}
@@ -74,6 +75,8 @@ fn test_app() -> App {
 pub fn bench_on_message(c: &mut Criterion) {
     use std::io::BufRead;
 
+    let _ = tracing_subscriber::fmt::try_init();
+
     let f = std::fs::File::open("messages.raw.json").unwrap();
     let reader = BufReader::new(f);
     let mut data = Vec::new();
@@ -83,6 +86,7 @@ pub fn bench_on_message(c: &mut Criterion) {
         let content = Content::try_from(content_base64).unwrap();
         data.push(content);
     }
+    info!(n = %data.len(), "messages");
 
     c.bench_function("on_message", move |b| {
         b.to_async(tokio::runtime::Runtime::new().unwrap())

--- a/benches/app.rs
+++ b/benches/app.rs
@@ -1,0 +1,102 @@
+use std::io::BufReader;
+
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+use gurk::app::App;
+use gurk::config::{Config, User};
+use gurk::data::{AppData, Channel, ChannelId, GroupData, Message, TypingSet};
+use gurk::dev::ContentBase64;
+use gurk::signal::test::SignalManagerMock;
+use gurk::signal::GroupMasterKeyBytes;
+use gurk::storage::Storage;
+use gurk::util::StatefulList;
+use presage::prelude::Content;
+use uuid::Uuid;
+
+pub struct InMemoryStorage {}
+
+impl InMemoryStorage {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Storage for InMemoryStorage {
+    fn save_app_data(&self, _data: &AppData) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn load_app_data(&self) -> anyhow::Result<AppData> {
+        Ok(Default::default())
+    }
+}
+
+fn test_app() -> App {
+    let signal_manager = SignalManagerMock::new();
+
+    let mut app = App::try_new(
+        Config {
+            notifications: false,
+            ..Config::with_user(User {
+                name: "Tyler Durden".to_string(),
+                phone_number: "+0000000000".to_string(),
+            })
+        },
+        Box::new(signal_manager),
+        Box::new(InMemoryStorage::new()),
+    )
+    .unwrap();
+
+    app.data.channels.items.push(Channel {
+        id: ChannelId::User(Uuid::new_v4()),
+        name: "test".to_string(),
+        group_data: Some(GroupData {
+            master_key_bytes: GroupMasterKeyBytes::default(),
+            members: vec![app.user_id],
+            revision: 1,
+        }),
+        messages: StatefulList::with_items(vec![Message {
+            from_id: app.user_id,
+            message: Some("First message".to_string()),
+            arrived_at: 0,
+            quote: Default::default(),
+            attachments: Default::default(),
+            reactions: Default::default(),
+            receipt: Default::default(),
+        }]),
+        unread_messages: 1,
+        typing: TypingSet::GroupTyping(Default::default()),
+    });
+    app.data.channels.state.select(Some(0));
+
+    app
+}
+
+pub fn bench_on_message(c: &mut Criterion) {
+    use std::io::BufRead;
+
+    let f = std::fs::File::open("messages.raw.json").unwrap();
+    let reader = BufReader::new(f);
+    let mut data = Vec::new();
+    for line in reader.lines() {
+        let line = line.unwrap();
+        let content_base64: ContentBase64 = serde_json::from_str(&line).unwrap();
+        let content = Content::try_from(content_base64).unwrap();
+        data.push(content);
+    }
+
+    c.bench_function("on_message", move |b| {
+        b.to_async(tokio::runtime::Runtime::new().unwrap())
+            .iter_batched(
+                || (test_app(), data.clone()),
+                |(mut app, data)| async move {
+                    for content in data {
+                        app.on_message(content).await.unwrap();
+                    }
+                },
+                BatchSize::SmallInput,
+            )
+    });
+}
+
+criterion_group!(benches, bench_on_message);
+criterion_main!(benches);

--- a/benches/app.rs
+++ b/benches/app.rs
@@ -1,22 +1,17 @@
-use std::io::BufReader;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
 
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use gurk::app::App;
 use gurk::config::{Config, User};
-use gurk::data::{Channel, ChannelId, GroupData, Message, TypingSet};
 use gurk::dev::ContentBase64;
 use gurk::signal::test::SignalManagerMock;
-use gurk::signal::GroupMasterKeyBytes;
 use gurk::storage::InMemoryStorage;
-use gurk::util::StatefulList;
 use presage::prelude::Content;
 use tracing::info;
-use uuid::Uuid;
 
 fn test_app() -> App {
-    let signal_manager = SignalManagerMock::new();
-
-    let mut app = App::try_new(
+    App::try_new(
         Config {
             notifications: false,
             ..Config::with_user(User {
@@ -24,52 +19,15 @@ fn test_app() -> App {
                 phone_number: "+0000000000".to_string(),
             })
         },
-        Box::new(signal_manager),
+        Box::new(SignalManagerMock::new()),
         Box::new(InMemoryStorage::new()),
     )
-    .unwrap();
-
-    app.data.channels.items.push(Channel {
-        id: ChannelId::User(Uuid::new_v4()),
-        name: "test".to_string(),
-        group_data: Some(GroupData {
-            master_key_bytes: GroupMasterKeyBytes::default(),
-            members: vec![app.user_id],
-            revision: 1,
-        }),
-        messages: StatefulList::with_items(vec![Message {
-            from_id: app.user_id,
-            message: Some("First message".to_string()),
-            arrived_at: 0,
-            quote: Default::default(),
-            attachments: Default::default(),
-            reactions: Default::default(),
-            receipt: Default::default(),
-        }]),
-        unread_messages: 1,
-        typing: TypingSet::GroupTyping(Default::default()),
-    });
-    app.data.channels.state.select(Some(0));
-
-    app
+    .unwrap()
 }
 
 pub fn bench_on_message(c: &mut Criterion) {
-    use std::io::BufRead;
-
     let _ = tracing_subscriber::fmt::try_init();
-
-    let f = std::fs::File::open("messages.raw.json").unwrap();
-    let reader = BufReader::new(f);
-    let mut data = Vec::new();
-    for line in reader.lines() {
-        let line = line.unwrap();
-        let content_base64: ContentBase64 = serde_json::from_str(&line).unwrap();
-        let content = Content::try_from(content_base64).unwrap();
-        data.push(content);
-    }
-    info!(n = %data.len(), "messages");
-
+    let data = read_input_data("messages.raw.json");
     c.bench_function("on_message", move |b| {
         b.to_async(tokio::runtime::Runtime::new().unwrap())
             .iter_batched(
@@ -82,6 +40,20 @@ pub fn bench_on_message(c: &mut Criterion) {
                 BatchSize::SmallInput,
             )
     });
+}
+
+fn read_input_data(path: impl AsRef<Path>) -> Vec<Content> {
+    let f = std::fs::File::open(path).unwrap();
+    let reader = BufReader::new(f);
+    let mut data = Vec::new();
+    for line in reader.lines() {
+        let line = line.unwrap();
+        let content_base64: ContentBase64 = serde_json::from_str(&line).unwrap();
+        let content = Content::try_from(content_base64).unwrap();
+        data.push(content);
+    }
+    info!(n = %data.len(), "messages");
+    data
 }
 
 criterion_group!(benches, bench_on_message);

--- a/benches/app.rs
+++ b/benches/app.rs
@@ -3,33 +3,15 @@ use std::io::BufReader;
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use gurk::app::App;
 use gurk::config::{Config, User};
-use gurk::data::{AppData, Channel, ChannelId, GroupData, Message, TypingSet};
+use gurk::data::{Channel, ChannelId, GroupData, Message, TypingSet};
 use gurk::dev::ContentBase64;
 use gurk::signal::test::SignalManagerMock;
 use gurk::signal::GroupMasterKeyBytes;
-use gurk::storage::Storage;
+use gurk::storage::InMemoryStorage;
 use gurk::util::StatefulList;
 use presage::prelude::Content;
 use tracing::info;
 use uuid::Uuid;
-
-pub struct InMemoryStorage {}
-
-impl InMemoryStorage {
-    pub fn new() -> Self {
-        Self {}
-    }
-}
-
-impl Storage for InMemoryStorage {
-    fn save_app_data(&self, _data: &AppData) -> anyhow::Result<()> {
-        Ok(())
-    }
-
-    fn load_app_data(&self) -> anyhow::Result<AppData> {
-        Ok(Default::default())
-    }
-}
 
 fn test_app() -> App {
     let signal_manager = SignalManagerMock::new();

--- a/src/app.rs
+++ b/src/app.rs
@@ -30,8 +30,6 @@ use std::borrow::Cow;
 use std::cmp::Reverse;
 use std::collections::HashSet;
 use std::convert::TryInto;
-use std::fs::OpenOptions;
-use std::io::BufWriter;
 use std::path::Path;
 
 /// Amount of time to skip contacts sync after the last sync
@@ -335,7 +333,7 @@ impl App {
         // tracing::debug!("incoming: {:#?}", content);
 
         if self.config.developer.dump_raw_messages {
-            if let Err(e) = dump_raw_message(&content) {
+            if let Err(e) = crate::dev::dump_raw_message(&content) {
                 warn!(error = %e, "failed to dump raw message");
             }
         }
@@ -1196,23 +1194,6 @@ impl App {
         });
         self.data.channels = channels;
     }
-}
-
-fn dump_raw_message(content: &Content) -> anyhow::Result<()> {
-    use std::io::Write;
-
-    let f = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open("messages.raw.json")?;
-    let mut writer = BufWriter::new(f);
-
-    let content = crate::dev::ContentBase64::from(content);
-
-    serde_json::to_writer(&mut writer, &content)?;
-    writeln!(writer)?;
-
-    Ok(())
 }
 
 /// Returns an emoji string if `s` is an emoji or if `s` is a GitHub emoji shortcode.

--- a/src/app.rs
+++ b/src/app.rs
@@ -332,6 +332,7 @@ impl App {
     pub async fn on_message(&mut self, content: Content) -> anyhow::Result<()> {
         // tracing::debug!("incoming: {:#?}", content);
 
+        #[cfg(feature = "dev")]
         if self.config.developer.dump_raw_messages {
             if let Err(e) = crate::dev::dump_raw_message(&content) {
                 warn!(error = %e, "failed to dump raw message");

--- a/src/app.rs
+++ b/src/app.rs
@@ -1210,7 +1210,7 @@ fn dump_raw_message(content: &Content) -> anyhow::Result<()> {
     let content = crate::dev::ContentBase64::from(content);
 
     serde_json::to_writer(&mut writer, &content)?;
-    writeln!(writer, "")?;
+    writeln!(writer)?;
 
     Ok(())
 }
@@ -1258,7 +1258,7 @@ mod tests {
     use crate::config::User;
     use crate::data::GroupData;
     use crate::signal::test::SignalManagerMock;
-    use crate::storage::test::InMemoryStorage;
+    use crate::storage::InMemoryStorage;
 
     use std::cell::RefCell;
     use std::rc::Rc;

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,6 +23,7 @@ pub struct Config {
     pub notifications: bool,
     /// User configuration
     pub user: User,
+    #[cfg(feature = "dev")]
     #[serde(default, skip_serializing_if = "DeveloperConfig::is_default")]
     pub developer: DeveloperConfig,
 }
@@ -35,12 +36,14 @@ pub struct User {
     pub phone_number: String,
 }
 
+#[cfg(feature = "dev")]
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DeveloperConfig {
     /// Dump raw messages to `messages.json` for collecting debug/benchmark data
     pub dump_raw_messages: bool,
 }
 
+#[cfg(feature = "dev")]
 impl DeveloperConfig {
     fn is_default(&self) -> bool {
         self == &Self::default()
@@ -57,6 +60,7 @@ impl Config {
             first_name_only: false,
             show_receipts: true,
             notifications: true,
+            #[cfg(feature = "dev")]
             developer: Default::default(),
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,8 +18,12 @@ pub struct Config {
     /// Whether to show receipts (sent, delivered, read) information next to your user name in UI
     #[serde(default = "default_true")]
     pub show_receipts: bool,
+    #[serde(default = "default_true")]
+    pub notifications: bool,
     /// User configuration
     pub user: User,
+    #[serde(default, skip_serializing_if = "DeveloperConfig::is_default")]
+    pub developer: DeveloperConfig,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -28,6 +32,18 @@ pub struct User {
     pub name: String,
     /// Phone number used in Signal
     pub phone_number: String,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeveloperConfig {
+    /// Dump raw messages to `messages.json` for collecting debug/benchmark data
+    pub dump_raw_messages: bool,
+}
+
+impl DeveloperConfig {
+    fn is_default(&self) -> bool {
+        self == &Self::default()
+    }
 }
 
 impl Config {
@@ -39,6 +55,8 @@ impl Config {
             signal_db_path: default_signal_db_path(),
             first_name_only: false,
             show_receipts: true,
+            notifications: true,
+            developer: Default::default(),
         }
     }
 

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -302,7 +302,7 @@ impl Cursor {
         let end = text[self.idx..]
             .char_indices()
             .find(|&(_, c)| c == '\n')
-            .map(&|(idx, _)| idx)
+            .map(|(idx, _)| idx)
             .unwrap_or_else(|| text.len());
         if self.idx == end && end < text.len() {
             text.remove(end);

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -1,0 +1,81 @@
+use presage::prelude::proto::{CallMessage, ReceiptMessage, TypingMessage};
+use presage::prelude::{Content, ContentBody, DataMessage, Metadata, ServiceAddress, SyncMessage};
+use prost::Message;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+pub struct ContentBase64 {
+    #[serde(with = "MetadataDef")]
+    pub metadata: Metadata,
+    pub body_type: ContentBodyType,
+    pub body_proto_base64: String,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "Metadata")]
+struct MetadataDef {
+    sender: ServiceAddress,
+    sender_device: u32,
+    timestamp: u64,
+    needs_receipt: bool,
+}
+
+impl From<Metadata> for MetadataDef {
+    fn from(metadata: Metadata) -> Self {
+        Self {
+            sender: metadata.sender,
+            sender_device: metadata.sender_device,
+            timestamp: metadata.timestamp,
+            needs_receipt: metadata.needs_receipt,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub enum ContentBodyType {
+    DataMessage,
+    SynchronizeMessage,
+    CallMessage,
+    ReceiptMessage,
+    TypingMessage,
+}
+
+impl From<&Content> for ContentBase64 {
+    fn from(content: &Content) -> Self {
+        use ContentBody::*;
+        let (body_type, body_proto_bytes) = match &content.body {
+            DataMessage(msg) => (ContentBodyType::DataMessage, msg.encode_to_vec()),
+            SynchronizeMessage(msg) => (ContentBodyType::SynchronizeMessage, msg.encode_to_vec()),
+            CallMessage(msg) => (ContentBodyType::CallMessage, msg.encode_to_vec()),
+            ReceiptMessage(msg) => (ContentBodyType::ReceiptMessage, msg.encode_to_vec()),
+            TypingMessage(msg) => (ContentBodyType::TypingMessage, msg.encode_to_vec()),
+        };
+
+        let body_proto_base64 = base64::encode(&body_proto_bytes);
+        Self {
+            metadata: content.metadata.clone(),
+            body_type,
+            body_proto_base64,
+        }
+    }
+}
+
+impl TryFrom<ContentBase64> for Content {
+    type Error = anyhow::Error;
+
+    fn try_from(content: ContentBase64) -> Result<Self, Self::Error> {
+        let body_bytes = base64::decode(&content.body_proto_base64)?;
+        let buf = body_bytes.as_slice();
+        let body = match content.body_type {
+            ContentBodyType::DataMessage => DataMessage::decode(buf)?.into(),
+            ContentBodyType::SynchronizeMessage => SyncMessage::decode(buf)?.into(),
+            ContentBodyType::CallMessage => CallMessage::decode(buf)?.into(),
+            ContentBodyType::ReceiptMessage => ReceiptMessage::decode(buf)?.into(),
+            ContentBodyType::TypingMessage => TypingMessage::decode(buf)?.into(),
+        };
+        Ok(Self {
+            metadata: content.metadata,
+            body,
+        })
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,14 @@
+//! Signal Messenger client for terminal
+
+pub mod app;
+pub mod config;
+pub mod cursor;
+pub mod data;
+pub mod dev;
+pub mod input;
+pub mod receipt;
+pub mod shortcuts;
+pub mod signal;
+pub mod storage;
+pub mod ui;
+pub mod util;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod app;
 pub mod config;
 pub mod cursor;
 pub mod data;
+#[cfg(feature = "dev")]
 pub mod dev;
 pub mod input;
 pub mod receipt;

--- a/src/signal/mod.rs
+++ b/src/signal/mod.rs
@@ -1,6 +1,5 @@
 mod r#impl;
 mod manager;
-#[cfg(test)]
 pub mod test;
 
 use anyhow::{bail, Context as _};

--- a/src/signal/test.rs
+++ b/src/signal/test.rs
@@ -26,10 +26,16 @@ pub struct SignalManagerMock {
 impl SignalManagerMock {
     pub fn new() -> Self {
         Self {
-            user_id: Uuid::new_v4(),
+            user_id: Uuid::nil(),
             emoji_replacer: Replacer::new(),
             sent_messages: Default::default(),
         }
+    }
+}
+
+impl Default for SignalManagerMock {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/signal/test.rs
+++ b/src/signal/test.rs
@@ -65,7 +65,7 @@ impl SignalManager for SignalManagerMock {
         Ok(Attachment {
             id,
             content_type: attachment_pointer.content_type.unwrap(),
-            filename: attachment_pointer.file_name.unwrap().into(),
+            filename: "somefile".to_string().into(),
             size: attachment_pointer.size.unwrap(),
         })
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -75,7 +75,7 @@ impl JsonStorage {
 
         // if data file exists, be conservative and fail rather than overriding and losing the messages
         if data_path.exists() {
-            Self::load_app_data_from(&data_path).with_context(|| {
+            Self::load_app_data_from(data_path).with_context(|| {
                 format!(
                     "failed to load stored data from '{}':\n\
             This might happen due to incompatible data model when Gurk is upgraded.\n\

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -95,29 +95,23 @@ impl JsonStorage {
     }
 }
 
-#[cfg(test)]
-pub mod test {
-    use crate::data::AppData;
+/// In-memory storage used for testing.
+#[derive(Default)]
+pub struct InMemoryStorage {}
 
-    use super::Storage;
+impl InMemoryStorage {
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
 
-    /// In-memory storage used for testing.
-    pub struct InMemoryStorage {}
-
-    impl InMemoryStorage {
-        pub fn new() -> Self {
-            Self {}
-        }
+impl Storage for InMemoryStorage {
+    fn save_app_data(&self, _data: &AppData) -> anyhow::Result<()> {
+        Ok(())
     }
 
-    impl Storage for InMemoryStorage {
-        fn save_app_data(&self, _data: &AppData) -> anyhow::Result<()> {
-            Ok(())
-        }
-
-        fn load_app_data(&self) -> anyhow::Result<AppData> {
-            Ok(Default::default())
-        }
+    fn load_app_data(&self) -> anyhow::Result<AppData> {
+        Ok(Default::default())
     }
 }
 

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -18,7 +18,7 @@ use crate::data::Message;
 use crate::receipt::{Receipt, ReceiptEvent};
 use crate::shortcuts::{ShortCut, SHORTCUTS};
 use crate::util::utc_timestamp_msec_to_local;
-use crate::App;
+use crate::app::App;
 
 use super::name_resolver::NameResolver;
 use super::CHANNEL_VIEW_RATIO;

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -13,12 +13,12 @@ use tui::Frame;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 use uuid::Uuid;
 
+use crate::app::App;
 use crate::cursor::Cursor;
 use crate::data::Message;
 use crate::receipt::{Receipt, ReceiptEvent};
 use crate::shortcuts::{ShortCut, SHORTCUTS};
 use crate::util::utc_timestamp_msec_to_local;
-use crate::app::App;
 
 use super::name_resolver::NameResolver;
 use super::CHANNEL_VIEW_RATIO;

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,7 +5,8 @@ use serde::{Deserialize, Serialize};
 use tui::widgets::ListState;
 
 use crate::data::Channel;
-use crate::MESSAGE_SCROLL_BACK;
+
+const MESSAGE_SCROLL_BACK: bool = false;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct StatefulList<T> {


### PR DESCRIPTION
As input for the benchmark we use a list of raw incoming messages
(metadata + base64 encoded serialized protobuf). To collect those use
the configuration

```toml
[developer]
dump_raw_messages = true
```

The benchmark measures how long it takes to process all collected
messages.

Collecting messages and running the benchmark is behind a feature
flag `dev`. Run the benchmark with

```
cargo bench --features dev
```