### PR TITLE
Fix xtask musl build error

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,6 +72,10 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+      - name: Build and run xtask
+        uses: actions-rs/cargo@v1
+        with:
+          command: xtask
 
   build-x86_64-unknown-linux-musl:
     name: build (x86_64-unknown-linux-musl)
@@ -98,6 +102,12 @@ jobs:
         with:
           command: build
           args: --target x86_64-unknown-linux-musl
+      - name: Build and run xtask
+        uses: actions-rs/cargo@v1
+        # xtask miscompiles on musl platform without explicit target flag
+        with:
+          command: build
+          args: -p xtask --target x86_64-unknown-linux-musl
 
   build-aarch64-unknown-linux-gnu:
     name: build (aarch64-unknown-linux-gnu)
@@ -121,6 +131,10 @@ jobs:
         with:
           command: build
           args: --target aarch64-unknown-linux-gnu
+      - name: Build and run xtask
+        uses: actions-rs/cargo@v1
+        with:
+          command: xtask
 
   build-aarch64-unknown-linux-musl:
     name: build (aarch64-unknown-linux-musl)
@@ -145,9 +159,10 @@ jobs:
           override: true
       - name: Build
         uses: actions-rs/cargo@v1
+        # xtask miscompiles on musl platform without explicit target flag
         with:
-          command: build
-          args: --target x86_64-unknown-linux-musl
+          command: run
+          args: -p xtask --target x86_64-unknown-linux-musl
 
   build-test-x86_64-apple-darwin:
     name: build and test (x86_64-apple-darwin)
@@ -175,6 +190,10 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+      - name: Build and run xtask
+        uses: actions-rs/cargo@v1
+        with:
+          command: xtask
 
   build-aarch64-apple-darwin:
     name: build (aarch64-apple-darwin)
@@ -200,3 +219,7 @@ jobs:
         with:
           command: build
           args: --target aarch64-apple-darwin
+      - name: Build and run xtask
+        uses: actions-rs/cargo@v1
+        with:
+          command: xtask

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,8 @@
 name: release
-# on:
-#   push:
-#     tags:
-#       - 'v*.*.*'
-on: [push, pull_request]
+on:
+  push:
+    tags:
+      - 'v*.*.*'
 
 env:
   CARGO_INCREMENTAL: 0
@@ -12,27 +11,27 @@ env:
   FETCH_DEPTH: 0 # pull in the tags for the version string
 
 jobs:
-  # dist-changelog:
-  #   name: dist (changelog)
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: ${{ env.FETCH_DEPTH }}
-  #     - name: Install Rust toolchain
-  #       uses: actions-rs/toolchain@v1
-  #       with:
-  #         toolchain: stable
-  #         profile: minimal
-  #         override: true
-  #     - name: Generate checklog
-  #       run: cargo xtask changelog
-  #     - name: Upload artifacts
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: dist-changelog
-  #         path: dist
+  dist-changelog:
+    name: dist (changelog)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: ${{ env.FETCH_DEPTH }}
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: Generate checklog
+        run: cargo xtask changelog
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist-changelog
+          path: dist
 
   dist-x86_64-unknown-linux-gnu:
     name: dist (x86_64-unknown-linux-gnu)
@@ -202,53 +201,53 @@ jobs:
           name: dist-aarch64-apple-darwin
           path: dist
 
-  # publish:
-  #   name: publish
-  #   runs-on: ubuntu-18.04
-  #   needs:
-  #     - dist-changelog
-  #     - dist-x86_64-unknown-linux-gnu
-  #     - dist-x86_64-unknown-linux-musl
-  #     - dist-aarch64-unknown-linux-gnu
-  #     - dist-aarch64-unknown-linux-musl
-  #     - dist-x86_64-apple-darwin
-  #     - dist-aarch64-apple-darwin
-  #   steps:
-  #     - uses: actions/download-artifact@v2
-  #       with:
-  #         name: dist-changelog
-  #         path: dist
-  #     - uses: actions/download-artifact@v2
-  #       with:
-  #         name: dist-aarch64-apple-darwin
-  #         path: dist
-  #     - uses: actions/download-artifact@v2
-  #       with:
-  #         name: dist-x86_64-apple-darwin
-  #         path: dist
-  #     - uses: actions/download-artifact@v2
-  #       with:
-  #         name: dist-x86_64-unknown-linux-gnu
-  #         path: dist
-  #     - uses: actions/download-artifact@v2
-  #       with:
-  #         name: dist-x86_64-unknown-linux-musl
-  #         path: dist
-  #     - uses: actions/download-artifact@v2
-  #       with:
-  #         name: dist-aarch64-unknown-linux-gnu
-  #         path: dist
-  #     - uses: actions/download-artifact@v2
-  #       with:
-  #         name: dist-aarch64-unknown-linux-musl
-  #         path: dist
-  #     - run: ls -al
-  #       working-directory: dist
-  #     - name: Release
-  #       uses: softprops/action-gh-release@v1
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #       with:
-  #         body_path: dist/CHANGELOG.md
-  #         files: dist/*.tar.gz
-  #         draft: true
+  publish:
+    name: publish
+    runs-on: ubuntu-18.04
+    needs:
+      - dist-changelog
+      - dist-x86_64-unknown-linux-gnu
+      - dist-x86_64-unknown-linux-musl
+      - dist-aarch64-unknown-linux-gnu
+      - dist-aarch64-unknown-linux-musl
+      - dist-x86_64-apple-darwin
+      - dist-aarch64-apple-darwin
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: dist-changelog
+          path: dist
+      - uses: actions/download-artifact@v2
+        with:
+          name: dist-aarch64-apple-darwin
+          path: dist
+      - uses: actions/download-artifact@v2
+        with:
+          name: dist-x86_64-apple-darwin
+          path: dist
+      - uses: actions/download-artifact@v2
+        with:
+          name: dist-x86_64-unknown-linux-gnu
+          path: dist
+      - uses: actions/download-artifact@v2
+        with:
+          name: dist-x86_64-unknown-linux-musl
+          path: dist
+      - uses: actions/download-artifact@v2
+        with:
+          name: dist-aarch64-unknown-linux-gnu
+          path: dist
+      - uses: actions/download-artifact@v2
+        with:
+          name: dist-aarch64-unknown-linux-musl
+          path: dist
+      - run: ls -al
+        working-directory: dist
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          body_path: dist/CHANGELOG.md
+          files: dist/*.tar.gz
+          draft: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,27 +12,27 @@ env:
   FETCH_DEPTH: 0 # pull in the tags for the version string
 
 jobs:
-  dist-changelog:
-    name: dist (changelog)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: ${{ env.FETCH_DEPTH }}
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-      - name: Generate checklog
-        run: cargo xtask changelog
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: dist-changelog
-          path: dist
+  # dist-changelog:
+  #   name: dist (changelog)
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: ${{ env.FETCH_DEPTH }}
+  #     - name: Install Rust toolchain
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: stable
+  #         profile: minimal
+  #         override: true
+  #     - name: Generate checklog
+  #       run: cargo xtask changelog
+  #     - name: Upload artifacts
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: dist-changelog
+  #         path: dist
 
   dist-x86_64-unknown-linux-gnu:
     name: dist (x86_64-unknown-linux-gnu)
@@ -140,7 +140,7 @@ jobs:
           override: true
       - name: Dist
         # FIXME: building xtask without explicit target segfaults rustc
-        run: cargo run -p xtask --target aarch64-unknown-linux-musl  -- dist
+        run: cargo run -p xtask --target x86_64-unknown-linux-musl  -- dist
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,9 @@
 name: release
-on:
-  push:
-    tags:
-      - 'v*.*.*'
+# on:
+#   push:
+#     tags:
+#       - 'v*.*.*'
+on: [push, pull_request]
 
 env:
   CARGO_INCREMENTAL: 0
@@ -79,7 +80,8 @@ jobs:
           target: x86_64-unknown-linux-musl
           override: true
       - name: Dist
-        run: cargo xtask dist
+        # FIXME: building xtask without explicit target segfaults rustc
+        run: cargo run -p xtask --target x86_64-unknown-linux-musl  -- dist
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -137,7 +139,8 @@ jobs:
           target: aarch64-unknown-linux-musl
           override: true
       - name: Dist
-        run: cargo xtask dist
+        # FIXME: building xtask without explicit target segfaults rustc
+        run: cargo run -p xtask --target aarch64-unknown-linux-musl  -- dist
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -199,53 +202,53 @@ jobs:
           name: dist-aarch64-apple-darwin
           path: dist
 
-  publish:
-    name: publish
-    runs-on: ubuntu-18.04
-    needs:
-      - dist-changelog
-      - dist-x86_64-unknown-linux-gnu
-      - dist-x86_64-unknown-linux-musl
-      - dist-aarch64-unknown-linux-gnu
-      - dist-aarch64-unknown-linux-musl
-      - dist-x86_64-apple-darwin
-      - dist-aarch64-apple-darwin
-    steps:
-      - uses: actions/download-artifact@v2
-        with:
-          name: dist-changelog
-          path: dist
-      - uses: actions/download-artifact@v2
-        with:
-          name: dist-aarch64-apple-darwin
-          path: dist
-      - uses: actions/download-artifact@v2
-        with:
-          name: dist-x86_64-apple-darwin
-          path: dist
-      - uses: actions/download-artifact@v2
-        with:
-          name: dist-x86_64-unknown-linux-gnu
-          path: dist
-      - uses: actions/download-artifact@v2
-        with:
-          name: dist-x86_64-unknown-linux-musl
-          path: dist
-      - uses: actions/download-artifact@v2
-        with:
-          name: dist-aarch64-unknown-linux-gnu
-          path: dist
-      - uses: actions/download-artifact@v2
-        with:
-          name: dist-aarch64-unknown-linux-musl
-          path: dist
-      - run: ls -al
-        working-directory: dist
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          body_path: dist/CHANGELOG.md
-          files: dist/*.tar.gz
-          draft: true
+  # publish:
+  #   name: publish
+  #   runs-on: ubuntu-18.04
+  #   needs:
+  #     - dist-changelog
+  #     - dist-x86_64-unknown-linux-gnu
+  #     - dist-x86_64-unknown-linux-musl
+  #     - dist-aarch64-unknown-linux-gnu
+  #     - dist-aarch64-unknown-linux-musl
+  #     - dist-x86_64-apple-darwin
+  #     - dist-aarch64-apple-darwin
+  #   steps:
+  #     - uses: actions/download-artifact@v2
+  #       with:
+  #         name: dist-changelog
+  #         path: dist
+  #     - uses: actions/download-artifact@v2
+  #       with:
+  #         name: dist-aarch64-apple-darwin
+  #         path: dist
+  #     - uses: actions/download-artifact@v2
+  #       with:
+  #         name: dist-x86_64-apple-darwin
+  #         path: dist
+  #     - uses: actions/download-artifact@v2
+  #       with:
+  #         name: dist-x86_64-unknown-linux-gnu
+  #         path: dist
+  #     - uses: actions/download-artifact@v2
+  #       with:
+  #         name: dist-x86_64-unknown-linux-musl
+  #         path: dist
+  #     - uses: actions/download-artifact@v2
+  #       with:
+  #         name: dist-aarch64-unknown-linux-gnu
+  #         path: dist
+  #     - uses: actions/download-artifact@v2
+  #       with:
+  #         name: dist-aarch64-unknown-linux-musl
+  #         path: dist
+  #     - run: ls -al
+  #       working-directory: dist
+  #     - name: Release
+  #       uses: softprops/action-gh-release@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         body_path: dist/CHANGELOG.md
+  #         files: dist/*.tar.gz
+  #         draft: true


### PR DESCRIPTION
Workaround for a segmentation fault when running xtask on
musl platforms: add explicit `--target` flag with exec platform.