### PR TITLE
Update presage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1754,7 +1754,7 @@ dependencies = [
 [[package]]
 name = "libsignal-service"
 version = "0.1.0"
-source = "git+https://github.com/whisperfish/libsignal-service-rs?rev=0e851d867a33e74008335a4174da8a8c47faba33#0e851d867a33e74008335a4174da8a8c47faba33"
+source = "git+https://github.com/whisperfish/libsignal-service-rs?rev=ddccf7431d7fe848ef8fbed487fc0d33fe385b23#ddccf7431d7fe848ef8fbed487fc0d33fe385b23"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1787,7 +1787,7 @@ dependencies = [
 [[package]]
 name = "libsignal-service-hyper"
 version = "0.1.0"
-source = "git+https://github.com/whisperfish/libsignal-service-rs?rev=0e851d867a33e74008335a4174da8a8c47faba33#0e851d867a33e74008335a4174da8a8c47faba33"
+source = "git+https://github.com/whisperfish/libsignal-service-rs?rev=ddccf7431d7fe848ef8fbed487fc0d33fe385b23#ddccf7431d7fe848ef8fbed487fc0d33fe385b23"
 dependencies = [
  "async-trait",
  "async-tungstenite",
@@ -2533,8 +2533,8 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "presage"
-version = "0.4.0"
-source = "git+https://github.com/whisperfish/presage?rev=faef707#faef7072b4b6d37971e7411bc3bba8a8a6c24517"
+version = "0.4.1-dev"
+source = "git+https://github.com/whisperfish/presage?rev=d1d72ab#d1d72ab825762c53524cc46ac24bb5aff9f8e6d0"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
@@ -2546,6 +2546,7 @@ dependencies = [
  "libsignal-service-hyper",
  "log",
  "matrix-sdk-store-encryption",
+ "parking_lot 0.11.2",
  "prost 0.10.4",
  "prost-build 0.10.4",
  "rand 0.7.3",
@@ -2554,6 +2555,7 @@ dependencies = [
  "sha2 0.10.6",
  "sled",
  "thiserror",
+ "tokio",
  "url",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ debug = true
 dev = ["prost", "base64"]
 
 [dependencies]
-presage = { git = "https://github.com/whisperfish/presage", rev = "faef707" }
+presage = { git = "https://github.com/whisperfish/presage", rev = "d1d72ab" }
 
 anyhow = "1.0.66"
 async-trait = "0.1.58"

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -1,7 +1,6 @@
 use std::fs::OpenOptions;
 use std::io::BufWriter;
 
-use anyhow::anyhow;
 use presage::prelude::proto;
 use presage::prelude::{Content, Metadata, ServiceAddress};
 use prost::Message;
@@ -21,6 +20,7 @@ struct MetadataDef {
     sender_device: u32,
     timestamp: u64,
     needs_receipt: bool,
+    unidentified_sender: bool,
 }
 
 impl From<Metadata> for MetadataDef {
@@ -30,6 +30,7 @@ impl From<Metadata> for MetadataDef {
             sender_device: metadata.sender_device,
             timestamp: metadata.timestamp,
             needs_receipt: metadata.needs_receipt,
+            unidentified_sender: metadata.unidentified_sender,
         }
     }
 }
@@ -51,8 +52,7 @@ impl TryFrom<ContentBase64> for Content {
     fn try_from(content: ContentBase64) -> Result<Self, Self::Error> {
         let content_bytes = base64::decode(&content.content_proto_base64)?;
         let content_proto = proto::Content::decode(&*content_bytes)?;
-        Self::from_proto(content_proto, content.metadata)
-            .ok_or_else(|| anyhow!("invalid content proto"))
+        Ok(Self::from_proto(content_proto, content.metadata)?)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,7 +92,7 @@ pub enum Event {
 }
 
 async fn run_single_threaded(relink: bool) -> anyhow::Result<()> {
-    let (signal_manager, config) = signal::ensure_linked_device(relink).await?;
+    let (mut signal_manager, config) = signal::ensure_linked_device(relink).await?;
 
     let storage = JsonStorage::new(&config.data_path, config::fallback_data_path().as_deref())?;
     let mut app = App::try_new(config, signal_manager.clone_boxed(), Box::new(storage))?;

--- a/src/signal/impl.rs
+++ b/src/signal/impl.rs
@@ -289,7 +289,7 @@ impl SignalManager for PresageManager {
         Ok(self.manager.get_contact_by_id(id)?)
     }
 
-    async fn receive_messages(&self) -> anyhow::Result<Pin<Box<dyn Stream<Item = Content>>>> {
+    async fn receive_messages(&mut self) -> anyhow::Result<Pin<Box<dyn Stream<Item = Content>>>> {
         Ok(Box::pin(self.manager.receive_messages().await?))
     }
 }

--- a/src/signal/manager.rs
+++ b/src/signal/manager.rs
@@ -56,7 +56,7 @@ pub trait SignalManager {
     /// This usually happens shortly after the latter method is called.
     fn contact_by_id(&self, id: Uuid) -> anyhow::Result<Option<Contact>>;
 
-    async fn receive_messages(&self) -> anyhow::Result<Pin<Box<dyn Stream<Item = Content>>>>;
+    async fn receive_messages(&mut self) -> anyhow::Result<Pin<Box<dyn Stream<Item = Content>>>>;
 }
 
 pub struct ResolvedGroup {

--- a/src/signal/test.rs
+++ b/src/signal/test.rs
@@ -127,7 +127,7 @@ impl SignalManager for SignalManagerMock {
         Ok(None)
     }
 
-    async fn receive_messages(&self) -> anyhow::Result<Pin<Box<dyn Stream<Item = Content>>>> {
+    async fn receive_messages(&mut self) -> anyhow::Result<Pin<Box<dyn Stream<Item = Content>>>> {
         Ok(Box::pin(tokio_stream::empty()))
     }
 


### PR DESCRIPTION
This should at least fix #208 and probably some other small issues related to how some HTTP responses are handled by `libsignal-service-rs` (this will for example make use of the internal websocket for sending messages, instead of direct HTTP API calls).