### PR TITLE
Implement storing and rendering of mentions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Added
 
--  Copy selected message to clipboard ([#210])
+- Copy selected message to clipboard ([#210])
+- Implement storing and rendering of mentions ([#215, #136])
 
 ### Changed
 
@@ -17,6 +18,8 @@
 [#203]: https://github.com/boxdot/gurk-rs/pull/203
 [#204]: https://github.com/boxdot/gurk-rs/pull/204
 [#210]: https://github.com/boxdot/gurk-rs/pull/210
+[#136]: https://github.com/boxdot/gurk-rs/pull/136
+[#215]: https://github.com/boxdot/gurk-rs/pull/215
 
 ## 0.3.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1330,6 +1330,7 @@ dependencies = [
 name = "gurk"
 version = "0.4.0-dev"
 dependencies = [
+ "aho-corasick",
  "anyhow",
  "arboard",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ tracing-subscriber = "0.3.16"
 futures-channel = "0.3.25"
 qr2term = "0.3.1"
 clap = { version = "4.0.19", features = ["derive"] }
+aho-corasick = "0.7.19"
 
 # dev feature dependencies
 prost = { version = "0.10.4", optional = true }

--- a/src/signal/impl.rs
+++ b/src/signal/impl.rs
@@ -144,6 +144,7 @@ impl SignalManager for PresageManager {
             id: Some(message.arrived_at),
             author_uuid: Some(message.from_id.to_string()),
             text: message.message.clone(),
+            body_ranges: message.body_ranges.iter().map(From::from).collect(),
             ..Default::default()
         });
         let quote_message = quote.clone().and_then(Message::from_quote).map(Box::new);
@@ -213,6 +214,7 @@ impl SignalManager for PresageManager {
             attachments: Default::default(),
             reactions: Default::default(),
             receipt: Receipt::Sent,
+            body_ranges: Default::default(),
         }
     }
 

--- a/src/signal/test.rs
+++ b/src/signal/test.rs
@@ -103,6 +103,7 @@ impl SignalManager for SignalManagerMock {
             reactions: Default::default(),
             // TODO make sure the message sending procedure did not fail
             receipt: Receipt::Sent,
+            body_ranges: Default::default(),
         };
         self.sent_messages.borrow_mut().push(message.clone());
         message

--- a/src/storage/json.rs
+++ b/src/storage/json.rs
@@ -333,6 +333,7 @@ mod tests {
                 attachments: Default::default(),
                 reactions: Default::default(),
                 receipt: Default::default(),
+                body_ranges: Default::default(),
             }],
             unread_messages: 1,
             typing: Some(TypingSet::SingleTyping(false)),
@@ -349,6 +350,7 @@ mod tests {
                 attachments: Default::default(),
                 reactions: Default::default(),
                 receipt: Default::default(),
+                body_ranges: Default::default(),
             }],
             unread_messages: 2,
             typing: Some(TypingSet::GroupTyping(Default::default())),
@@ -496,6 +498,7 @@ mod tests {
                 attachments: Default::default(),
                 reactions: Default::default(),
                 receipt: Default::default(),
+                body_ranges: Default::default(),
             },
         );
 

--- a/src/storage/snapshots/gurk__storage__json__tests__json_storage_data_model.snap
+++ b/src/storage/snapshots/gurk__storage__json__tests__json_storage_data_model.snap
@@ -19,7 +19,8 @@ expression: data
             "quote": null,
             "attachments": [],
             "reactions": [],
-            "receipt": "Nothing"
+            "receipt": "Nothing",
+            "body_ranges": []
           }
         ],
         "unread_messages": 1
@@ -71,7 +72,8 @@ expression: data
             "quote": null,
             "attachments": [],
             "reactions": [],
-            "receipt": "Nothing"
+            "receipt": "Nothing",
+            "body_ranges": []
           }
         ],
         "unread_messages": 2

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -970,16 +970,19 @@ mod tests {
         let show_receipt = ShowReceipt::from_msg(&msg, USER_ID, true);
         let rendered = display_message(&names, &msg, PREFIX, WIDTH, HEIGHT, show_receipt);
 
-        let expected = ListItem::new(Text::from(vec![Spans(vec![
-            Span::styled("  ", Style::default().fg(Color::Yellow)),
-            Span::styled(
-                display_time(msg.arrived_at),
-                Style::default().fg(Color::Yellow),
-            ),
-            Span::styled("boxdot", Style::default().fg(Color::Green)),
-            Span::raw(": "),
-            Span::raw("Mention @boxdot and even more @boxdot. End"),
-        ])]));
+        let expected = ListItem::new(Text::from(vec![
+            Spans(vec![
+                Span::styled("  ", Style::default().fg(Color::Yellow)),
+                Span::styled(
+                    display_time(msg.arrived_at),
+                    Style::default().fg(Color::Yellow),
+                ),
+                Span::styled("boxdot", Style::default().fg(Color::Green)),
+                Span::raw(": "),
+                Span::raw("Mention @boxdot  and even more @boxdot ."),
+            ]),
+            Spans(vec![Span::raw("                  End")]),
+        ]));
         assert_eq!(rendered, Some(expected));
     }
 }

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -16,7 +16,7 @@ use uuid::Uuid;
 use crate::app::App;
 use crate::channels::SelectChannel;
 use crate::cursor::Cursor;
-use crate::data::Message;
+use crate::data::{AssociatedValue, Message};
 use crate::receipt::{Receipt, ReceiptEvent};
 use crate::shortcuts::{ShortCut, SHORTCUTS};
 use crate::storage::MessageId;
@@ -474,7 +474,8 @@ fn display_message(
         .subsequent_indent(prefix);
 
     // collect message text
-    let mut text = msg.message.clone().unwrap_or_default();
+    let text = msg.message.clone().unwrap_or_default();
+    let mut text = replace_mentions(msg, names, text);
     add_attachments(msg, &mut text);
     if text.is_empty() {
         return None; // no text => nothing to render
@@ -541,6 +542,32 @@ fn display_message(
         spans.push(Spans::from(format!("{prefix}[...]")));
     }
     Some(ListItem::new(Text::from(spans)))
+}
+
+fn replace_mentions(msg: &Message, names: &NameResolver, text: String) -> String {
+    if msg.body_ranges.is_empty() {
+        return text;
+    }
+
+    let ac = aho_corasick::AhoCorasickBuilder::new()
+        .build(std::iter::repeat("￼").take(msg.body_ranges.len()));
+    let mut buf = String::with_capacity(text.len());
+    let mut ranges = msg.body_ranges.iter();
+    ac.replace_all_with(&text, &mut buf, |_, _, dst| {
+        // TODO: check ranges?
+        if let Some(range) = ranges.next() {
+            let (name, _color) = match range.value {
+                AssociatedValue::MentionUuid(id) => names.resolve(id),
+            };
+            dst.push('@');
+            dst.push_str(&name);
+            true
+        } else {
+            false
+        }
+    });
+
+    buf
 }
 
 fn display_date_line(
@@ -668,7 +695,8 @@ fn draw_help<B: Backend>(f: &mut Frame<B>, app: &mut App, area: Rect) {
 
 fn displayed_quote(names: &NameResolver, quote: &Message) -> Option<String> {
     let (name, _) = names.resolve(quote.from_id);
-    Some(format!("({}) {}", name, quote.message.as_ref()?))
+    let text = format!("({}) {}", name, quote.message.as_ref()?);
+    Some(replace_mentions(quote, names, text))
 }
 
 fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
@@ -699,6 +727,7 @@ fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
 
 #[cfg(test)]
 mod tests {
+    use crate::data::{AssociatedValue, BodyRange};
     use crate::signal::Attachment;
 
     use super::*;
@@ -729,9 +758,10 @@ mod tests {
             message: None,
             arrived_at: 1642334397421,
             quote: None,
-            attachments: vec![],
-            reactions: vec![],
+            attachments: Default::default(),
+            reactions: Default::default(),
             receipt: Receipt::Sent,
+            body_ranges: Default::default(),
         }
     }
 
@@ -911,6 +941,44 @@ mod tests {
             Span::styled("boxdot", Style::default().fg(Color::Green)),
             Span::raw(": "),
             Span::raw("Hello, World!"),
+        ])]));
+        assert_eq!(rendered, Some(expected));
+    }
+
+    #[test]
+    fn test_display_mention() {
+        let user_id = Uuid::from_u128(1);
+        let names = NameResolver::single_user(user_id, "boxdot".to_string(), Color::Green);
+        let msg = Message {
+            from_id: user_id,
+            message: Some("Mention ￼  and even more ￼ . End".into()),
+            receipt: Receipt::Read,
+            body_ranges: vec![
+                BodyRange {
+                    start: 8,
+                    end: 9,
+                    value: AssociatedValue::MentionUuid(user_id),
+                },
+                BodyRange {
+                    start: 25,
+                    end: 26,
+                    value: AssociatedValue::MentionUuid(user_id),
+                },
+            ],
+            ..test_message()
+        };
+        let show_receipt = ShowReceipt::from_msg(&msg, USER_ID, true);
+        let rendered = display_message(&names, &msg, PREFIX, WIDTH, HEIGHT, show_receipt);
+
+        let expected = ListItem::new(Text::from(vec![Spans(vec![
+            Span::styled("  ", Style::default().fg(Color::Yellow)),
+            Span::styled(
+                display_time(msg.arrived_at),
+                Style::default().fg(Color::Yellow),
+            ),
+            Span::styled("boxdot", Style::default().fg(Color::Green)),
+            Span::raw(": "),
+            Span::raw("Mention @boxdot and even more @boxdot. End"),
         ])]));
         assert_eq!(rendered, Some(expected));
     }


### PR DESCRIPTION
The placeholder obj tag sometimes has a space behind it and sometimes
not. For now, we replace just the obj tag, which might have several
spaces after it but it definitely works.

Closes #136 