### PR TITLE
Fix blocking contacts sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,12 @@
 ### Fixed
 
 - Do not create log file when logging is disabled ([#204])
+- Fix blocking contacts sync ([#216])
 
 [#203]: https://github.com/boxdot/gurk-rs/pull/203
 [#204]: https://github.com/boxdot/gurk-rs/pull/204
 [#210]: https://github.com/boxdot/gurk-rs/pull/210
+[#216]: https://github.com/boxdot/gurk-rs/pull/216
 
 ## 0.3.0
 


### PR DESCRIPTION
Presage has a timeout of 3 min of contact sync. We timeout now after 10
secs. Otherwise, the app does not start. Blocking was introduced in
presage via #214.