### PR TITLE
feat: add ephemeral status to sent messages on errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,9 +458,9 @@ checksum = "17cc5e6b5ab06331c33589842070416baa137e8b0eb912b008cfd4a78ada7919"
 
 [[package]]
 name = "chrono"
-version = "0.4.22"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "iana-time-zone",
  "num-integer",
@@ -1787,7 +1787,7 @@ dependencies = [
 [[package]]
 name = "libsignal-service"
 version = "0.1.0"
-source = "git+https://github.com/whisperfish/libsignal-service-rs?rev=f11b2d1#f11b2d1683925ff52b2cfcd86a350405379b0336"
+source = "git+https://github.com/whisperfish/libsignal-service-rs?rev=c2f70ef#c2f70efd88bbebc9b646690a8449c451af619f2c"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1820,7 +1820,7 @@ dependencies = [
 [[package]]
 name = "libsignal-service-hyper"
 version = "0.1.0"
-source = "git+https://github.com/whisperfish/libsignal-service-rs?rev=f11b2d1#f11b2d1683925ff52b2cfcd86a350405379b0336"
+source = "git+https://github.com/whisperfish/libsignal-service-rs?rev=c2f70ef#c2f70efd88bbebc9b646690a8449c451af619f2c"
 dependencies = [
  "async-trait",
  "async-tungstenite",
@@ -2573,7 +2573,7 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 [[package]]
 name = "presage"
 version = "0.6.0-dev"
-source = "git+https://github.com/whisperfish/presage?rev=7823d28#7823d28e89606cc44c9042df30c6203750e925ac"
+source = "git+https://github.com/whisperfish/presage?rev=0.5.2#673d30686c8da8df6f45d2e9cf9d2d5eec2651c9"
 dependencies = [
  "base64 0.12.3",
  "futures",
@@ -2592,7 +2592,7 @@ dependencies = [
 [[package]]
 name = "presage-store-sled"
 version = "0.6.0-dev"
-source = "git+https://github.com/whisperfish/presage?rev=7823d28#7823d28e89606cc44c9042df30c6203750e925ac"
+source = "git+https://github.com/whisperfish/presage?rev=0.5.2#673d30686c8da8df6f45d2e9cf9d2d5eec2651c9"
 dependencies = [
  "async-trait",
  "base64 0.12.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,7 +214,7 @@ checksum = "d7d78656ba01f1b93024b7c3a0467f1608e4be67d725749fdcd7d2c7678fd7a2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -231,7 +231,7 @@ checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -542,7 +542,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -859,7 +859,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -876,7 +876,7 @@ checksum = "309e4fb93eed90e1e14bea0da16b209f81813ba9fc7830c20ed151dd7bc0a4d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -887,7 +887,7 @@ checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -898,7 +898,7 @@ checksum = "3418329ca0ad70234b9735dc4ceed10af4df60eff9c8e7b06cb5e520d92c3535"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -970,7 +970,7 @@ checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1005,9 +1005,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "enumflags2"
-version = "0.7.5"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e75d4cd21b95383444831539909fbb14b9dc3fdceb2a6f5d36577329a1f55ccb"
+checksum = "c041f5090df68b32bcd905365fd51769c8b9d553fe87fde0b683534f10c01bd2"
 dependencies = [
  "enumflags2_derive",
  "serde",
@@ -1015,13 +1015,13 @@ dependencies = [
 
 [[package]]
 name = "enumflags2_derive"
-version = "0.7.4"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58dc3c5e468259f19f2d46304a6b28f1c3d034442e14b322d2b850e36f6d5ae"
+checksum = "5e9a1f9f7d83e59740248a6e14ecf93929ade55027844dfcea78beafccc15745"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1225,7 +1225,7 @@ checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -2171,7 +2171,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -2418,7 +2418,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -2629,7 +2629,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
  "version_check",
 ]
 
@@ -2652,9 +2652,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -2731,7 +2731,7 @@ dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -2744,7 +2744,7 @@ dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -2835,14 +2835,14 @@ checksum = "b22a693222d716a9587786f37ac3f6b4faedb5b80c23914e7303ff5a1d8016e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -3174,7 +3174,7 @@ checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -3196,7 +3196,7 @@ checksum = "1fe39d9fbb0ebf5eb2c7cb7e2a47e4f462fad1379f1166b8ae49ad9eae89a7ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -3400,7 +3400,7 @@ dependencies = [
  "heck 0.3.3",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -3421,6 +3421,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3428,7 +3439,7 @@ checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
  "unicode-xid",
 ]
 
@@ -3514,7 +3525,7 @@ checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -3625,7 +3636,7 @@ checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -3710,7 +3721,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -3992,7 +4003,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
  "wasm-bindgen-shared",
 ]
 
@@ -4014,7 +4025,7 @@ checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4492,7 +4503,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -4523,7 +4534,7 @@ checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
  "synstructure",
 ]
 
@@ -4567,5 +4578,5 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2573,7 +2573,7 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 [[package]]
 name = "presage"
 version = "0.6.0-dev"
-source = "git+https://github.com/whisperfish/presage?rev=0.5.1#c9198cb15a3a4cf0aea12a08272a230451ac12f8"
+source = "git+https://github.com/whisperfish/presage?rev=7823d28#7823d28e89606cc44c9042df30c6203750e925ac"
 dependencies = [
  "base64 0.12.3",
  "futures",
@@ -2592,7 +2592,7 @@ dependencies = [
 [[package]]
 name = "presage-store-sled"
 version = "0.6.0-dev"
-source = "git+https://github.com/whisperfish/presage?rev=0.5.1#c9198cb15a3a4cf0aea12a08272a230451ac12f8"
+source = "git+https://github.com/whisperfish/presage?rev=7823d28#7823d28e89606cc44c9042df30c6203750e925ac"
 dependencies = [
  "async-trait",
  "base64 0.12.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ debug = true
 dev = ["prost", "base64"]
 
 [dependencies]
-presage = { git = "https://github.com/whisperfish/presage", rev = "7823d28" }
-presage-store-sled = { git = "https://github.com/whisperfish/presage", rev = "7823d28" }
+presage = { git = "https://github.com/whisperfish/presage", rev = "0.5.2" }
+presage-store-sled = { git = "https://github.com/whisperfish/presage", rev = "0.5.2" }
 
 anyhow = "1.0.66"
 async-trait = "0.1.58"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ debug = true
 dev = ["prost", "base64"]
 
 [dependencies]
-presage = { git = "https://github.com/whisperfish/presage", rev = "0.5.1" }
-presage-store-sled = { git = "https://github.com/whisperfish/presage", rev = "0.5.1" }
+presage = { git = "https://github.com/whisperfish/presage", rev = "7823d28" }
+presage-store-sled = { git = "https://github.com/whisperfish/presage", rev = "7823d28" }
 
 anyhow = "1.0.66"
 async-trait = "0.1.58"

--- a/src/data.rs
+++ b/src/data.rs
@@ -130,6 +130,8 @@ pub struct Message {
     pub receipt: Receipt,
     #[serde(default)]
     pub(crate) body_ranges: Vec<BodyRange>,
+    #[serde(skip)]
+    pub(crate) send_failed: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -236,6 +238,7 @@ impl Message {
             reactions: Default::default(),
             receipt: Receipt::Sent,
             body_ranges: body_ranges.into_iter().collect(),
+            send_failed: Default::default(),
         }
     }
 
@@ -253,6 +256,7 @@ impl Message {
                 .into_iter()
                 .filter_map(BodyRange::from_proto)
                 .collect(),
+            send_failed: Default::default(),
         })
     }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,0 +1,9 @@
+use crate::storage::MessageId;
+
+#[derive(Debug)]
+pub enum Event {
+    SentTextResult {
+        message_id: MessageId,
+        result: anyhow::Result<()>,
+    },
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod cursor;
 pub mod data;
 #[cfg(feature = "dev")]
 pub mod dev;
+pub mod event;
 pub mod input;
 pub mod receipt;
 pub mod shortcuts;

--- a/src/signal/impl.rs
+++ b/src/signal/impl.rs
@@ -47,7 +47,7 @@ impl SignalManager for PresageManager {
     }
 
     fn user_id(&self) -> Uuid {
-        self.manager.uuid()
+        self.manager.state().service_ids.aci
     }
 
     async fn resolve_group(

--- a/src/signal/manager.rs
+++ b/src/signal/manager.rs
@@ -7,6 +7,7 @@ use async_trait::async_trait;
 use presage::prelude::proto::AttachmentPointer;
 use presage::prelude::{AttachmentSpec, Contact, Content};
 use serde::{Deserialize, Serialize};
+use tokio::sync::oneshot;
 use tokio_stream::Stream;
 use uuid::Uuid;
 
@@ -40,7 +41,7 @@ pub trait SignalManager {
         text: String,
         quote_message: Option<&Message>,
         attachments: Vec<(AttachmentSpec, Vec<u8>)>,
-    ) -> Message;
+    ) -> (Message, oneshot::Receiver<anyhow::Result<()>>);
 
     fn send_reaction(&self, channel: &Channel, message: &Message, emoji: String, remove: bool);
 

--- a/src/signal/mod.rs
+++ b/src/signal/mod.rs
@@ -40,7 +40,7 @@ pub async fn ensure_linked_device(
 
     if !relink {
         if let Some(config) = config.clone() {
-            if let Ok(manager) = presage::Manager::load_registered(store.clone()) {
+            if let Ok(manager) = presage::Manager::load_registered(store.clone()).await {
                 // done loading manager from store
                 return Ok((Box::new(PresageManager::new(manager)), config));
             }

--- a/src/storage/json.rs
+++ b/src/storage/json.rs
@@ -334,6 +334,7 @@ mod tests {
                 reactions: Default::default(),
                 receipt: Default::default(),
                 body_ranges: Default::default(),
+                send_failed: Default::default(),
             }],
             unread_messages: 1,
             typing: Some(TypingSet::SingleTyping(false)),
@@ -351,6 +352,7 @@ mod tests {
                 reactions: Default::default(),
                 receipt: Default::default(),
                 body_ranges: Default::default(),
+                send_failed: Default::default(),
             }],
             unread_messages: 2,
             typing: Some(TypingSet::GroupTyping(Default::default())),
@@ -499,6 +501,7 @@ mod tests {
                 reactions: Default::default(),
                 receipt: Default::default(),
                 body_ranges: Default::default(),
+                send_failed: Default::default(),
             },
         );
 

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -530,11 +530,21 @@ fn display_message(
                         Span::from(line.strip_prefix(prefix).unwrap().to_string()),
                     ]
                 } else {
-                    vec![Span::from(line.to_string())]
+                    vec![Span::from(line.into_owned())]
                 };
                 Spans::from(res)
             }),
     );
+
+    if let Some(reason) = msg.send_failed.as_deref() {
+        let error = format!("[Could no send: {reason}]");
+        let error_style = Style::default().fg(Color::Red);
+        spans.extend(
+            textwrap::wrap(&error, &wrap_opts)
+                .into_iter()
+                .map(|line| Span::styled(line.into_owned(), error_style).into()),
+        );
+    }
 
     if spans.len() > height {
         // span is too big to be shown fully
@@ -762,6 +772,7 @@ mod tests {
             reactions: Default::default(),
             receipt: Receipt::Sent,
             body_ranges: Default::default(),
+            send_failed: Default::default(),
         }
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -94,7 +94,8 @@ impl<T> StatefulList<T> {
 }
 
 pub fn utc_timestamp_msec_to_local(timestamp: u64) -> DateTime<Local> {
-    let dt = NaiveDateTime::from_timestamp(timestamp as i64 / 1000, (timestamp % 1000) as u32);
+    let dt = NaiveDateTime::from_timestamp_opt(timestamp as i64 / 1000, (timestamp % 1000) as u32)
+        .expect("invalid datetime");
     Utc.from_utc_datetime(&dt).with_timezone(&Local)
 }
 

--- a/xtask/src/changelog.rs
+++ b/xtask/src/changelog.rs
@@ -26,7 +26,7 @@ fn get_version() -> Result<Version> {
         .map_err(|_| anyhow!("missing GITHUB_REF; not running in GitHub actions?"))?;
     github_ref
         .strip_prefix("refs/tags/v")
-        .map(|s| Version::parse(s))
+        .map(Version::parse)
         .transpose()?
         .ok_or_else(|| {
             anyhow!(
@@ -37,7 +37,7 @@ fn get_version() -> Result<Version> {
 }
 
 fn extract_section(changelog: &str, version: Version) -> Result<&str> {
-    let parser = Parser::new(&changelog);
+    let parser = Parser::new(changelog);
     let h2 = parser.into_offset_iter().filter_map(|(event, range)| {
         if let Event::Start(Tag::Heading(HeadingLevel::H2, _, _)) = event {
             Some(range)


### PR DESCRIPTION
Messages that could not be sent are marked as such by adding a read
field below showing the error message. The status is ephemeral and is
not stored. Resending of message is not implemented.

Also upgrade presage to incl. the fix which does not reuse websocket
connection for sending. This should fix sending messages.