### PR TITLE
feat: sync contacts and groups from signal manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Added
 
 - Copy selected message to clipboard ([#210])
-- Implement storing and rendering of mentions ([#215, #136])
+- Implement storing and rendering of mentions ([#215], [#136])
+- Sync contacts and groups from signal manager ([#226], [#227])
 
 ### Changed
 
@@ -22,6 +23,8 @@
 [#136]: https://github.com/boxdot/gurk-rs/pull/136
 [#215]: https://github.com/boxdot/gurk-rs/pull/215
 [#216]: https://github.com/boxdot/gurk-rs/pull/216
+[#226]: https://github.com/boxdot/gurk-rs/pull/226
+[#227]: https://github.com/boxdot/gurk-rs/pull/227
 
 ## 0.3.0
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,15 +15,14 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
+use gurk::app::App;
+use gurk::storage::{sync_from_signal, JsonStorage, MemCache, SqliteStorage, Storage};
 use gurk::{config, signal, ui};
 use presage::prelude::Content;
 use tokio::select;
 use tokio_stream::StreamExt;
 use tracing::{error, info, metadata::LevelFilter};
 use tui::{backend::CrosstermBackend, Terminal};
-
-use gurk::app::App;
-use gurk::storage::{JsonStorage, MemCache, SqliteStorage, Storage};
 
 const TARGET_FPS: u64 = 144;
 const RECEIPT_TICK_PERIOD: u64 = 144;
@@ -40,11 +39,6 @@ struct Args {
     /// Relinks the device (helpful when device was unlinked)
     #[clap(long)]
     relink: bool,
-    /// Dump raw messages to `messages.json` in the current working directory
-    ///
-    /// Used for collecting benchmark data
-    #[clap(long)]
-    dump_messages: bool,
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -99,7 +93,7 @@ pub enum Event {
 async fn run_single_threaded(relink: bool) -> anyhow::Result<()> {
     let (mut signal_manager, config) = signal::ensure_linked_device(relink).await?;
 
-    let storage: Box<dyn Storage> = if config.sqlite.enabled {
+    let mut storage: Box<dyn Storage> = if config.sqlite.enabled {
         let mut sqlite_storage = SqliteStorage::open(&config.sqlite.url).with_context(|| {
             format!(
                 "failed to open sqlite data storage at: {}",
@@ -129,19 +123,13 @@ async fn run_single_threaded(relink: bool) -> anyhow::Result<()> {
         Box::new(json_storage)
     };
 
+    sync_from_signal(&*signal_manager, &mut *storage);
+
     let (mut app, mut app_events) = App::try_new(config, signal_manager.clone_boxed(), storage)?;
 
     // sync task can be only spawned after we start to listen to message, because it relies on
     // message sender to be running
     let mut contact_sync_task = app.request_contacts_sync();
-
-    enable_raw_mode()?;
-    let _raw_mode_guard = scopeguard::guard((), |_| {
-        disable_raw_mode().unwrap();
-    });
-
-    let mut stdout = std::io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
 
     let (tx, mut rx) = tokio::sync::mpsc::channel::<Event>(100);
     tokio::spawn({
@@ -160,10 +148,6 @@ async fn run_single_threaded(relink: bool) -> anyhow::Result<()> {
             }
         }
     });
-
-    let backend = CrosstermBackend::new(stdout);
-
-    let mut terminal = Terminal::new(backend)?;
 
     let inner_tx = tx.clone();
     tokio::task::spawn_local(async move {
@@ -216,6 +200,16 @@ async fn run_single_threaded(relink: bool) -> anyhow::Result<()> {
         }
     });
 
+    enable_raw_mode()?;
+    let _raw_mode_guard = scopeguard::guard((), |_| {
+        disable_raw_mode().unwrap();
+    });
+
+    let mut stdout = std::io::stdout();
+    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
     terminal.clear()?;
 
     let mut res = Ok(()); // result on quit

--- a/src/signal/impl.rs
+++ b/src/signal/impl.rs
@@ -6,7 +6,7 @@ use anyhow::{anyhow, Context};
 use async_trait::async_trait;
 use chrono::Utc;
 use gh_emoji::Replacer;
-use presage::libsignal_service::prelude::ProfileKey;
+use presage::libsignal_service::prelude::{Group, ProfileKey};
 use presage::prelude::content::Reaction;
 use presage::prelude::proto::data_message::Quote;
 use presage::prelude::proto::{AttachmentPointer, ReceiptMessage};
@@ -315,6 +315,14 @@ impl SignalManager for PresageManager {
 
     async fn receive_messages(&mut self) -> anyhow::Result<Pin<Box<dyn Stream<Item = Content>>>> {
         Ok(Box::pin(self.manager.receive_messages().await?))
+    }
+
+    fn contacts(&self) -> Box<dyn Iterator<Item = Contact>> {
+        Box::new(self.manager.contacts().into_iter().flatten().flatten())
+    }
+
+    fn groups(&self) -> Box<dyn Iterator<Item = (GroupMasterKeyBytes, Group)>> {
+        Box::new(self.manager.groups().into_iter().flatten().flatten())
     }
 }
 

--- a/src/signal/manager.rs
+++ b/src/signal/manager.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use std::pin::Pin;
 
 use async_trait::async_trait;
+use presage::libsignal_service::prelude::Group;
 use presage::prelude::proto::AttachmentPointer;
 use presage::prelude::{AttachmentSpec, Contact, Content};
 use serde::{Deserialize, Serialize};
@@ -62,6 +63,9 @@ pub trait SignalManager {
     fn contact_by_id(&self, id: Uuid) -> anyhow::Result<Option<Contact>>;
 
     async fn receive_messages(&mut self) -> anyhow::Result<Pin<Box<dyn Stream<Item = Content>>>>;
+
+    fn contacts(&self) -> Box<dyn Iterator<Item = Contact>>;
+    fn groups(&self) -> Box<dyn Iterator<Item = (GroupMasterKeyBytes, Group)>>;
 }
 
 pub struct ResolvedGroup {

--- a/src/signal/test.rs
+++ b/src/signal/test.rs
@@ -3,7 +3,7 @@ use std::{cell::RefCell, rc::Rc};
 
 use async_trait::async_trait;
 use gh_emoji::Replacer;
-use presage::libsignal_service::prelude::AttachmentIdentifier;
+use presage::libsignal_service::prelude::{AttachmentIdentifier, Group};
 use presage::prelude::proto::data_message::Quote;
 use presage::prelude::proto::AttachmentPointer;
 use presage::prelude::{AttachmentSpec, Contact, Content};
@@ -15,7 +15,7 @@ use crate::data::{Channel, GroupData, Message};
 use crate::receipt::Receipt;
 use crate::util::utc_now_timestamp_msec;
 
-use super::{Attachment, ProfileKeyBytes, ResolvedGroup, SignalManager};
+use super::{Attachment, GroupMasterKeyBytes, ProfileKeyBytes, ResolvedGroup, SignalManager};
 
 /// Signal manager mock which does not send any messages.
 pub struct SignalManagerMock {
@@ -141,5 +141,13 @@ impl SignalManager for SignalManagerMock {
             emoji_replacer: Replacer::new(),
             sent_messages: self.sent_messages.clone(),
         })
+    }
+
+    fn contacts(&self) -> Box<dyn Iterator<Item = Contact>> {
+        Box::new(std::iter::empty())
+    }
+
+    fn groups(&self) -> Box<dyn Iterator<Item = (GroupMasterKeyBytes, Group)>> {
+        Box::new(std::iter::empty())
     }
 }

--- a/src/storage/copy.rs
+++ b/src/storage/copy.rs
@@ -1,3 +1,8 @@
+use tracing::{debug, error};
+
+use crate::data::{Channel, ChannelId, GroupData, TypingSet};
+use crate::signal::SignalManager;
+
 use super::Storage;
 
 #[derive(Debug, Default)]
@@ -28,4 +33,95 @@ pub fn copy(from: &dyn Storage, to: &mut dyn Storage) -> Stats {
     }
 
     stats
+}
+
+/// Copies contacts and groups from the signal manager into the storages
+///
+/// If contact/group is not in the storage, a new one is created. Group channels are updated,
+/// existing contacts are skipped. Contacts with empty name are also skipped.
+///
+/// Note: At the moment, there is no group sync implemented in presage, so only contacts are
+/// synced fully.
+pub fn sync_from_signal(manager: &dyn SignalManager, storage: &mut dyn Storage) {
+    for contact in manager.contacts() {
+        if contact.name.is_empty() {
+            // not sure what to do with contacts without a name
+            continue;
+        }
+        let channel_id = contact.uuid.into();
+        if storage.channel(channel_id).is_none() {
+            debug!(
+                name =% contact.name,
+                "storing new contact from signal manager"
+            );
+            storage.store_channel(Channel {
+                id: channel_id,
+                name: contact.name.trim().to_owned(),
+                group_data: None,
+                unread_messages: 0,
+                typing: TypingSet::new(false),
+            });
+        }
+    }
+
+    for (master_key_bytes, group) in manager.groups() {
+        let channel_id = match ChannelId::from_master_key_bytes(master_key_bytes) {
+            Ok(channel_id) => channel_id,
+            Err(error) => {
+                error!(%error, "failed to derive group id from master key bytes");
+                continue;
+            }
+        };
+        let new_group_data = || GroupData {
+            master_key_bytes,
+            members: group.members.iter().map(|member| member.uuid).collect(),
+            revision: group.revision,
+        };
+        match storage.channel(channel_id) {
+            Some(mut channel) => {
+                let mut is_changed = false;
+                if channel.name != group.title {
+                    channel.to_mut().name = group.title;
+                    is_changed = true;
+                }
+                if channel.group_data.as_ref().map(|d| d.revision) != Some(group.revision) {
+                    let group_data = channel
+                        .to_mut()
+                        .group_data
+                        .get_or_insert_with(new_group_data);
+                    group_data.revision = group.revision;
+                    is_changed = true;
+                }
+                if channel
+                    .group_data
+                    .as_ref()
+                    .map(|d| d.members.iter())
+                    .into_iter()
+                    .flatten()
+                    .ne(group.members.iter().map(|m| &m.uuid))
+                {
+                    let group_data = channel
+                        .to_mut()
+                        .group_data
+                        .get_or_insert_with(new_group_data);
+                    group_data.members = group.members.iter().map(|m| m.uuid).collect();
+                    is_changed = true;
+                }
+                if is_changed {
+                    debug!(?channel_id, "storing modified channel from signal manager");
+                    storage.store_channel(channel.into_owned());
+                }
+            }
+            None => {
+                debug!(?channel_id, "storing new channel from signal manager");
+                storage.store_channel(Channel {
+                    id: channel_id,
+                    name: group.title,
+                    group_data: Some(new_group_data()),
+                    unread_messages: 0,
+                    typing: TypingSet::new(true),
+                });
+            }
+        }
+    }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 
 use crate::data::{Channel, ChannelId, Message};
 
-pub use copy::copy;
+pub use copy::{copy, sync_from_signal};
 pub use forgetful::ForgetfulStorage;
 pub use json::JsonStorage;
 pub use memcache::MemCache;


### PR DESCRIPTION
Gurk copies new and changed contacts and groups from presage's signal
manager on startup. Since presage syncs the contacts when linking a new
secondary device, gurk does not start empty anymore on the first run.

Currently, presage/libsignal-service does not have an implementation for
group syncing, therefore groups are not synced.

Closes #226 