### PR TITLE
Add support for Ctrl+U to delete line backwards

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ libraries that are not available on crates.io.
   * `alt+enter` Switch between multi-line and singl-line input modes.
   * `alt+left`, `alt+right` Jump to previous/next word.
   * `ctrl+w / ctrl+backspace / alt+backspace` Delete last word.
+  * `ctrl+u` Delete to the start of the line.
   * `enter` *when input box empty in single-line mode* Open URL from selected message.
   * `enter` *otherwise* Send message.
 * Multi-line message input

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -124,6 +124,10 @@ impl Cursor {
         }
     }
 
+    pub fn delete_line_backward(&mut self, text: &mut String) {
+        (0..self.col.max(1)).for_each(|_| self.delete_backward(text))
+    }
+
     pub fn delete_word_backward(&mut self, text: &mut String) {
         let end = self.idx;
         self.move_word_left(text);

--- a/src/input.rs
+++ b/src/input.rs
@@ -54,6 +54,10 @@ impl Input {
         self.cursor.delete_backward(&mut self.data);
     }
 
+    pub fn on_delete_line(&mut self) {
+        self.cursor.delete_line_backward(&mut self.data);
+    }
+
     pub fn on_delete_word(&mut self) {
         self.cursor.delete_word_backward(&mut self.data);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -342,6 +342,9 @@ async fn run_single_threaded(relink: bool) -> anyhow::Result<()> {
                 KeyCode::Char('b') if event.modifiers.contains(KeyModifiers::ALT) => {
                     app.get_input().move_back_word();
                 }
+                KeyCode::Char('u') if event.modifiers.contains(KeyModifiers::CONTROL) => {
+                    app.get_input().on_delete_line();
+                }
                 KeyCode::Char('w') if event.modifiers.contains(KeyModifiers::CONTROL) => {
                     app.get_input().on_delete_word();
                 }

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -27,6 +27,10 @@ pub static SHORTCUTS: &[ShortCut] = &[
         description: "Delete last word.",
     },
     ShortCut {
+        event: "ctrl+u",
+        description: "Delete to the start of the line.",
+    },
+    ShortCut {
         event: "enter, when input box empty in single-line mode",
         description: "Open URL from selected message.",
     },


### PR DESCRIPTION
It is common behavior of Ctrl+U to delete line backwards, so I wanted to have support for it in gurk.

The desired behavior is as following. Given text (cursor indicated as `|`):

```
aaaaaaaaaaaa
bbbbbbbbbbbb
ccccccc|ddddd
```

Pressing `Ctrl+U` should result into:

```
aaaaaaaaaaaa
bbbbbbbbbbbb
|ddddd
```

Pressing again should result into:

```
aaaaaaaaaaaa
bbbbbbbbbbbb|ddddd
```

Then:

```
aaaaaaaaaaaa
|ddddd
```

Then:

```
aaaaaaaaaaaa|ddddd
```

Then:

```
|ddddd
```

Further presses of `Ctrl+U` would have no effect.

Let me know if it makes sense!
