### PR TITLE
Show attachment names or types

### DIFF
--- a/src/signal/impl.rs
+++ b/src/signal/impl.rs
@@ -160,6 +160,18 @@ impl SignalManager for PresageManager {
             ..Default::default()
         };
 
+        if has_attachments && message.is_empty() {
+            // TODO: Temporary solution until we start rendering attachments
+            message = format!(
+                "<attached: {}>",
+                attachments
+                    .iter()
+                    .map(|(a, _)| a.file_name.clone().unwrap_or(a.content_type.clone()))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+        }
+
         let (response_tx, response) = oneshot::channel();
         match channel.id {
             ChannelId::User(uuid) => {
@@ -214,11 +226,6 @@ impl SignalManager for PresageManager {
                     error!("cannot send to broken channel without group data");
                 }
             }
-        }
-
-        if has_attachments && message.is_empty() {
-            // TODO: Temporary solution until we start rendering attachments
-            message = "<attachment>".to_string();
         }
 
         let message = Message {


### PR DESCRIPTION
I totally realize this is still a temporary solution until a proper preview is in place, but I thought it could be a bit more useful if we can in the meantime at least see what attachments there were sent.

What do you think?
