### PR TITLE
fix: cache contact names

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -456,7 +456,7 @@ impl App {
     }
 
     pub async fn on_message(&mut self, content: Content) -> anyhow::Result<()> {
-        tracing::debug!("incoming: {:#?}", content);
+        // tracing::debug!("incoming: {:#?}", content);
 
         #[cfg(feature = "dev")]
         if self.config.developer.dump_raw_messages {

--- a/src/data.rs
+++ b/src/data.rs
@@ -246,7 +246,7 @@ impl BodyRange {
                 AssociatedValue::MentionUuid(uuid)
             }
             proto::body_range::AssociatedValue::Style(style) => AssociatedValue::Style(
-                proto::body_range::Style::try_from(style)
+                proto::body_range::Style::from_i32(style)
                     .map(Style::from_proto)
                     .unwrap_or_default(),
             ),

--- a/src/data.rs
+++ b/src/data.rs
@@ -246,7 +246,7 @@ impl BodyRange {
                 AssociatedValue::MentionUuid(uuid)
             }
             proto::body_range::AssociatedValue::Style(style) => AssociatedValue::Style(
-                proto::body_range::Style::from_i32(style)
+                proto::body_range::Style::try_from(style)
                     .map(Style::from_proto)
                     .unwrap_or_default(),
             ),


### PR DESCRIPTION
When rendering we look up the contact names in signal manager. This is an IO operation and so quite expensive. We cache now the names in memory.