### PR TITLE
Bump presage to e51f6f6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2474,9 +2474,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2257,7 +2257,7 @@ dependencies = [
 [[package]]
 name = "libsignal-service"
 version = "0.1.0"
-source = "git+https://github.com/whisperfish/libsignal-service-rs?rev=689a4c2#689a4c23292026f0d7067535988eb4a9e4bdb37a"
+source = "git+https://github.com/whisperfish/libsignal-service-rs?rev=c072491aa3e2b604b45b9f2b764552b7d382898c#c072491aa3e2b604b45b9f2b764552b7d382898c"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2292,7 +2292,7 @@ dependencies = [
 [[package]]
 name = "libsignal-service-hyper"
 version = "0.1.0"
-source = "git+https://github.com/whisperfish/libsignal-service-rs?rev=689a4c2#689a4c23292026f0d7067535988eb4a9e4bdb37a"
+source = "git+https://github.com/whisperfish/libsignal-service-rs?rev=c072491aa3e2b604b45b9f2b764552b7d382898c#c072491aa3e2b604b45b9f2b764552b7d382898c"
 dependencies = [
  "async-trait",
  "async-tungstenite",
@@ -3150,7 +3150,7 @@ checksum = "94e851c7654eed9e68d7d27164c454961a616cf8c203d500607ef22c737b51bb"
 [[package]]
 name = "presage"
 version = "0.6.1"
-source = "git+https://github.com/whisperfish/presage?rev=97e2357#97e235721efbc47da0872ab432e401f434b0ee99"
+source = "git+https://github.com/whisperfish/presage?rev=e51f6f6#e51f6f673500e8306e9d075d46e8ff4d34f6705d"
 dependencies = [
  "base64 0.21.7",
  "futures",
@@ -3170,7 +3170,7 @@ dependencies = [
 [[package]]
 name = "presage-store-cipher"
 version = "0.1.0"
-source = "git+https://github.com/whisperfish/presage?rev=97e2357#97e235721efbc47da0872ab432e401f434b0ee99"
+source = "git+https://github.com/whisperfish/presage?rev=e51f6f6#e51f6f673500e8306e9d075d46e8ff4d34f6705d"
 dependencies = [
  "blake3",
  "chacha20poly1305",
@@ -3187,7 +3187,7 @@ dependencies = [
 [[package]]
 name = "presage-store-sled"
 version = "0.6.0-dev"
-source = "git+https://github.com/whisperfish/presage?rev=97e2357#97e235721efbc47da0872ab432e401f434b0ee99"
+source = "git+https://github.com/whisperfish/presage?rev=e51f6f6#e51f6f673500e8306e9d075d46e8ff4d34f6705d"
 dependencies = [
  "async-trait",
  "base64 0.21.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ debug = true
 dev = ["prost", "base64"]
 
 [dependencies]
-presage = { git = "https://github.com/whisperfish/presage", rev = "97e2357" }
-presage-store-sled = { git = "https://github.com/whisperfish/presage", rev = "97e2357" }
+presage = { git = "https://github.com/whisperfish/presage", rev = "e51f6f6" }
+presage-store-sled = { git = "https://github.com/whisperfish/presage", rev = "e51f6f6" }
 
 # dev feature dependencies
 prost = { version = "0.10.4", optional = true }


### PR DESCRIPTION
To bring the fix from https://github.com/whisperfish/libsignal-service-rs/pull/297

Also includes:

* Workaround UUID not found errors (https://github.com/whisperfish/presage/pull/243)

This should fix #275