### PR TITLE
fix: show self send attachments #278

### DIFF
--- a/src/signal/impl.rs
+++ b/src/signal/impl.rs
@@ -132,9 +132,9 @@ impl SignalManager for PresageManager {
             ..Default::default()
         };
 
-        if has_attachments && message.is_empty() {
+        if has_attachments {
             // TODO: Temporary solution until we start rendering attachments
-            message = format!(
+            let attachment_message: String = format!(
                 "<attached: {}>",
                 attachments
                     .iter()
@@ -142,6 +142,11 @@ impl SignalManager for PresageManager {
                     .collect::<Vec<_>>()
                     .join(", ")
             );
+            if message.is_empty() {
+                message = attachment_message
+            } else {
+                message = message + "\n" + &attachment_message
+            }
         }
 
         let (response_tx, response) = oneshot::channel();


### PR DESCRIPTION
This pr makes gurk behave like the expected behavior described in #278.

These are my first lines of rust by the way :D
____
🩹 This might still just be a bandage 🩹
### Why?
How old messages are shown won't be changed by this pr rn.

 I don't know enough about the 🥒 yet, to know whether changing how old messages are shown is possible.

Therefore I don't know if it's smart to apply/use this patch (more inconsistency might be harder to change/'fix' afterwards.. ?).
