### PR TITLE
Key store and messages database encryption

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,11 +67,9 @@ jobs:
       image: rust:alpine
       volumes:
         - /usr/local/cargo/registry
-    env:
-      CC: clang
     steps:
       - name: system dependencies
-        run: apk add --no-cache tar musl-dev lld protoc bash clang llvm
+        run: apk add --no-cache tar musl-dev lld protoc bash clang llvm perl make
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@v1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,6 +67,8 @@ jobs:
       image: rust:alpine
       volumes:
         - /usr/local/cargo/registry
+    env:
+      CC: clang
     steps:
       - name: system dependencies
         run: apk add --no-cache tar musl-dev lld protoc bash clang llvm

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,7 +69,7 @@ jobs:
         - /usr/local/cargo/registry
     steps:
       - name: system dependencies
-        run: apk add --no-cache tar musl-dev lld protoc bash clang llvm perl make
+        run: apk add --no-cache tar musl-dev lld protoc bash clang llvm
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@v1
         with:
@@ -92,7 +92,7 @@ jobs:
           - aarch64-apple-darwin
     runs-on: macos-latest
     env:
-      SELECT_XCODE: /Applications/Xcode_13.2.app
+      SELECT_XCODE: /Applications/Xcode_15.3.app
     steps:
       - name: xcode
         run: sudo xcode-select -s "${SELECT_XCODE}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,7 +69,7 @@ jobs:
         - /usr/local/cargo/registry
     steps:
       - name: system dependencies
-        run: apk add --no-cache tar musl-dev lld protoc bash clang llvm
+        run: apk add --no-cache tar musl-dev lld protoc bash clang llvm make perl
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@v1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,6 +67,7 @@ jobs:
       volumes:
         - /usr/local/cargo/registry
     env:
+      CC: clang
       GURK_TARGET: ${{ matrix.target }}
     steps:
       - name: system dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,11 +67,10 @@ jobs:
       volumes:
         - /usr/local/cargo/registry
     env:
-      CC: clang
       GURK_TARGET: ${{ matrix.target }}
     steps:
       - name: system dependencies
-        run: apk add --no-cache musl-dev lld protoc bash clang llvm
+        run: apk add --no-cache musl-dev lld protoc bash clang llvm perl make
       - uses: actions/checkout@v4
         with:
           fetch-depth: ${{ env.FETCH_DEPTH }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,7 +70,7 @@ jobs:
       GURK_TARGET: ${{ matrix.target }}
     steps:
       - name: system dependencies
-        run: apk add --no-cache musl-dev lld protoc bash clang llvm perl make
+        run: apk add --no-cache musl-dev lld protoc bash clang llvm
       - uses: actions/checkout@v4
         with:
           fetch-depth: ${{ env.FETCH_DEPTH }}
@@ -96,7 +96,7 @@ jobs:
     runs-on: macos-latest
     env:
       GURK_TARGET: ${{ matrix.target }}
-      SELECT_XCODE: /Applications/Xcode_13.2.app
+      SELECT_XCODE: /Applications/Xcode_15.3.app
     steps:
       - name: xcode
         run: sudo xcode-select -s "${SELECT_XCODE}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,7 +70,7 @@ jobs:
       GURK_TARGET: ${{ matrix.target }}
     steps:
       - name: system dependencies
-        run: apk add --no-cache musl-dev lld protoc bash clang llvm
+        run: apk add --no-cache musl-dev lld protoc bash clang llvm make perl
       - uses: actions/checkout@v4
         with:
           fetch-depth: ${{ env.FETCH_DEPTH }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 gurk.log
 Session.vim
 messages.raw.json
+test.sqlite

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,16 +425,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "atomic-write-file"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edcdbedc2236483ab103a53415653d6b4442ea6141baf1ffa85df29635e88436"
-dependencies = [
- "nix 0.27.1",
- "rand",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1706,6 +1696,7 @@ dependencies = [
  "image",
  "insta",
  "itertools 0.10.5",
+ "libsqlite3-sys",
  "log-panics",
  "mime_guess",
  "notify-rust",
@@ -1739,6 +1730,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "unicode-width",
+ "url",
  "uuid",
  "whoami",
 ]
@@ -2523,17 +2515,6 @@ dependencies = [
  "libc",
  "memoffset 0.7.1",
  "pin-utils",
-]
-
-[[package]]
-name = "nix"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
-dependencies = [
- "bitflags 2.4.2",
- "cfg-if",
- "libc",
 ]
 
 [[package]]
@@ -4036,9 +4017,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dba03c279da73694ef99763320dea58b51095dfe87d001b1d4b5fe78ba8763cf"
+checksum = "c9a2ccff1a000a5a59cd33da541d9f2fdcd9e6e8229cc200565942bff36d0aaa"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -4049,9 +4030,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d84b0a3c3739e220d94b3239fd69fb1f74bc36e16643423bd99de3b43c21bfbd"
+checksum = "24ba59a9342a3d9bab6c56c118be528b27c9b60e490080e9711a04dccac83ef6"
 dependencies = [
  "ahash",
  "atoi",
@@ -4060,7 +4041,6 @@ dependencies = [
  "chrono",
  "crc",
  "crossbeam-queue",
- "dotenvy",
  "either",
  "event-listener 2.5.3",
  "futures-channel",
@@ -4094,9 +4074,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89961c00dc4d7dffb7aee214964b065072bff69e36ddb9e2c107541f75e4f2a5"
+checksum = "4ea40e2345eb2faa9e1e5e326db8c34711317d2b5e08d0d5741619048a803127"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4107,11 +4087,10 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0bd4519486723648186a08785143599760f7cc81c52334a55d6a83ea1e20841"
+checksum = "5833ef53aaa16d860e92123292f1f6a3d53c34ba8b1969f152ef1a7bb803f3c8"
 dependencies = [
- "atomic-write-file",
  "dotenvy",
  "either",
  "heck",
@@ -4134,9 +4113,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e37195395df71fd068f6e2082247891bc11e3289624bbc776a0cdfa1ca7f1ea4"
+checksum = "1ed31390216d20e538e447a7a9b959e06ed9fc51c37b514b46eb758016ecd418"
 dependencies = [
  "atoi",
  "base64 0.21.7",
@@ -4178,9 +4157,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ac0ac3b7ccd10cc96c7ab29791a7dd236bd94021f31eec7ba3d46a74aa1c24"
+checksum = "7c824eb80b894f926f89a0b9da0c7f435d27cdd35b8c655b114e58223918577e"
 dependencies = [
  "atoi",
  "base64 0.21.7",
@@ -4206,7 +4185,6 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
- "sha1",
  "sha2",
  "smallvec",
  "sqlx-core",
@@ -4219,9 +4197,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "210976b7d948c7ba9fced8ca835b11cbb2d677c59c79de41ac0d397e14547490"
+checksum = "b244ef0a8414da0bed4bb1910426e890b19e5e9bccc27ada6b797d05c55ae0aa"
 dependencies = [
  "atoi",
  "chrono",
@@ -5281,7 +5259,7 @@ dependencies = [
  "derive-new",
  "libc",
  "log",
- "nix 0.26.4",
+ "nix",
  "os_pipe",
  "tempfile",
  "thiserror",
@@ -5418,7 +5396,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "hex",
- "nix 0.26.4",
+ "nix",
  "once_cell",
  "ordered-stream",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4903,6 +4903,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5065,11 +5071,12 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.4.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50"
+checksum = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9"
 dependencies = [
- "wasm-bindgen",
+ "redox_syscall 0.4.1",
+ "wasite",
  "web-sys",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4903,12 +4903,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5071,12 +5065,11 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.5.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9"
+checksum = "22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50"
 dependencies = [
- "redox_syscall 0.4.1",
- "wasite",
+ "wasm-bindgen",
  "web-sys",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2314,6 +2314,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
 dependencies = [
  "cc",
+ "openssl-sys",
  "pkg-config",
  "vcpkg",
 ]
@@ -2711,6 +2712,28 @@ name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-src"
+version = "300.2.3+3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cff92b6f71555b61bb9315f7c64da3ca43d87531622120fea0195fc761b4843"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
+dependencies = [
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "ordered-stream"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ hostname = "0.3.1"
 image = { version = "0.24.6", default-features = false, features = ["png"] }
 itertools = "0.10.5"
 # not used directly; brings sqlcipher capabilities to sqlite
-libsqlite3-sys = { version = "0.27.0", features = ["bundled-sqlcipher"] }
+libsqlite3-sys = { version = "0.27.0", features = ["bundled-sqlcipher-vendored-openssl"] }
 log-panics = "2.1.0"
 mime_guess = "2.0.4"
 notify-rust = "4.5.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,8 @@ hex = "0.4.3"
 hostname = "0.3.1"
 image = { version = "0.24.6", default-features = false, features = ["png"] }
 itertools = "0.10.5"
+# not used directly; brings sqlcipher capabilities to sqlite
+libsqlite3-sys = { version = "0.27.0", features = ["bundled-sqlcipher"] }
 log-panics = "2.1.0"
 mime_guess = "2.0.4"
 notify-rust = "4.5.10"
@@ -66,7 +68,7 @@ scopeguard = "1.1.0"
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.87"
 sha2 = "0.10.8"
-sqlx = { version = "0.7.2", features = ["sqlite", "runtime-tokio-rustls", "uuid", "chrono"] }
+sqlx = { version = "0.7.4", features = ["sqlite", "runtime-tokio-rustls", "uuid", "chrono"] }
 textwrap = "0.16.0"
 thiserror = "1.0.40"
 thread_local = "1.1.7"
@@ -79,6 +81,8 @@ tracing-subscriber = "0.3.16"
 unicode-width = "0.1.10"
 uuid = { version = "1.2", features = ["v4"] }
 whoami = "1.2.3"
+url = "2.5.0"
+tempfile = "3.3.0"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["async_tokio", "html_reports"] }
@@ -86,7 +90,6 @@ hex-literal = "0.4.1"
 insta = { version = "1.21.0", features = ["json"] }
 quickcheck = "1.0.3"
 quickcheck_macros = "1.0.0"
-tempfile = "3.3.0"
 
 [[bench]]
 name = "app"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, bail, Context};
 use serde::{Deserialize, Serialize};
+use url::Url;
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -130,16 +131,37 @@ impl Config {
     }
 }
 
-#[derive(Debug, Default, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct SqliteConfig {
     pub enabled: bool,
     #[serde(default = "SqliteConfig::default_db_url")]
-    pub url: String,
+    pub url: Url,
+    /// If set, enables encryption of the database
+    pub passphrase: Option<String>,
+    /// Don't delete the unencrypted db, after applying encryption to it
+    ///
+    /// Useful for testing.
+    #[serde(default, rename = "_preserve_unencryped")]
+    pub preserve_unencrypted: bool,
+}
+
+impl Default for SqliteConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            url: Self::default_db_url(),
+            passphrase: Default::default(),
+            preserve_unencrypted: false,
+        }
+    }
 }
 
 impl SqliteConfig {
-    pub fn default_db_url() -> String {
-        default_data_dir().join("gurk.sqlite").display().to_string()
+    fn default_db_url() -> Url {
+        let path = default_data_dir().join("gurk.sqlite");
+        format!("sqlite://{}", path.display())
+            .parse()
+            .expect("invalid default sqlite path")
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,9 @@ pub struct Config {
     pub developer: DeveloperConfig,
     #[serde(default)]
     pub sqlite: SqliteConfig,
+    #[serde(default)]
+    /// If set, enables encryption of the key store and messages database
+    pub passphrase: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -69,6 +72,7 @@ impl Config {
             #[cfg(feature = "dev")]
             developer: Default::default(),
             sqlite: Default::default(),
+            passphrase: None,
         }
     }
 
@@ -136,8 +140,6 @@ pub struct SqliteConfig {
     pub enabled: bool,
     #[serde(default = "SqliteConfig::default_db_url")]
     pub url: Url,
-    /// If set, enables encryption of the database
-    pub passphrase: Option<String>,
     /// Don't delete the unencrypted db, after applying encryption to it
     ///
     /// Useful for testing.
@@ -150,7 +152,6 @@ impl Default for SqliteConfig {
         Self {
             enabled: false,
             url: Self::default_db_url(),
-            passphrase: Default::default(),
             preserve_unencrypted: false,
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,8 +97,17 @@ async fn run_single_threaded(relink: bool) -> anyhow::Result<()> {
     let (mut signal_manager, config) = signal::ensure_linked_device(relink).await?;
 
     let mut storage: Box<dyn Storage> = if config.sqlite.enabled {
-        debug!(config.sqlite.url, "opening sqlite");
-        let mut sqlite_storage = SqliteStorage::open(&config.sqlite.url).with_context(|| {
+        debug!(
+            %config.sqlite.url,
+            encrypt = config.sqlite.passphrase.is_some(),
+            "opening sqlite"
+        );
+        let mut sqlite_storage = SqliteStorage::maybe_encrypt_and_open(
+            &config.sqlite.url,
+            config.sqlite.passphrase.clone(),
+            config.sqlite.preserve_unencrypted,
+        )
+        .with_context(|| {
             format!(
                 "failed to open sqlite data storage at: {}",
                 config.sqlite.url

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,12 +99,12 @@ async fn run_single_threaded(relink: bool) -> anyhow::Result<()> {
     let mut storage: Box<dyn Storage> = if config.sqlite.enabled {
         debug!(
             %config.sqlite.url,
-            encrypt = config.sqlite.passphrase.is_some(),
+            encrypt = config.passphrase.is_some(),
             "opening sqlite"
         );
         let mut sqlite_storage = SqliteStorage::maybe_encrypt_and_open(
             &config.sqlite.url,
-            config.sqlite.passphrase.clone(),
+            config.passphrase.clone(),
             config.sqlite.preserve_unencrypted,
         )
         .with_context(|| {

--- a/src/signal/mod.rs
+++ b/src/signal/mod.rs
@@ -33,12 +33,17 @@ pub async fn ensure_linked_device(
     relink: bool,
 ) -> anyhow::Result<(Box<dyn SignalManager>, Config)> {
     let config = Config::load_installed()?;
+
     let db_path = config
         .as_ref()
         .map(|c| c.signal_db_path.clone())
         .unwrap_or_else(config::default_signal_db_path);
-    let store = SledStore::open(
+    let passphrase = config
+        .as_ref()
+        .and_then(|config| config.passphrase.as_ref());
+    let store = SledStore::open_with_passphrase(
         db_path,
+        passphrase,
         MigrationConflictStrategy::BackupAndDrop,
         OnNewIdentity::Trust,
     )?;

--- a/src/storage/sql/encrypt.rs
+++ b/src/storage/sql/encrypt.rs
@@ -1,0 +1,106 @@
+use std::fs::File;
+use std::io::Read;
+
+use anyhow::Context;
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqliteSynchronous};
+use sqlx::{ConnectOptions, Connection, SqliteConnection};
+use tempfile::tempdir;
+use tracing::info;
+use url::Url;
+
+pub(super) fn encrypt_db(
+    url: &Url,
+    passphrase: &str,
+    preserve_unencrypted: bool,
+) -> anyhow::Result<()> {
+    let opts: SqliteConnectOptions = url.as_str().parse()?;
+    let opts = opts
+        .create_if_missing(true)
+        .journal_mode(SqliteJournalMode::Wal)
+        .synchronous(SqliteSynchronous::Full)
+        .disable_statement_logging();
+
+    info!(%url, "encrypting db");
+
+    std::thread::scope(|s| {
+        s.spawn(|| -> anyhow::Result<()> {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            rt.block_on(async {
+                let tempdir = tempdir().context("failed to create temp dir")?;
+                let dest = tempdir.path().join("encrypted.db");
+
+                let mut conn = SqliteConnection::connect_with(&opts).await?;
+                sqlx::raw_sql(&format!(
+                    "
+                       ATTACH DATABASE '{}' AS encrypted KEY '{passphrase}';
+                       SELECT sqlcipher_export('encrypted');
+                       DETACH DATABASE encrypted;
+                    ",
+                    dest.display(),
+                ))
+                .execute(&mut conn)
+                .await
+                .context("failed to encrypt db")?;
+
+                let origin = url.path();
+                if preserve_unencrypted {
+                    let backup = format!("{origin}.backup");
+                    std::fs::copy(origin, &backup).with_context(|| {
+                        format!("failed to backup the unencrypted database at: {backup}")
+                    })?;
+                }
+
+                std::fs::copy(dest, origin)
+                    .with_context(|| format!("failed to replace unencrypted db at: {origin}"))?;
+
+                Ok(())
+            })
+        })
+        .join()
+        .expect("encryption failed")
+    })
+}
+
+pub(super) fn is_sqlite_encrypted_heuristics(url: &Url) -> Option<bool> {
+    const SQLITE3_HEADER: &[u8] = b"SQLite format 3\0";
+
+    let mut buf = [0; SQLITE3_HEADER.len()];
+    File::open(url.path()).ok()?.read_exact(&mut buf).ok()?;
+
+    Some(buf != SQLITE3_HEADER)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::storage::SqliteStorage;
+
+    use super::*;
+
+    #[test]
+    fn test_encrypt_unencrypted() -> anyhow::Result<()> {
+        let tempdir = tempdir().unwrap();
+        let path = tempdir.path().join("data.sqlite");
+        let url: Url = format!("sqlite://{}", path.display()).parse().unwrap();
+
+        let _ = SqliteStorage::open(&url, None).unwrap();
+        assert!(path.exists());
+        assert_eq!(is_sqlite_encrypted_heuristics(&url), Some(false));
+
+        let preserve_unencrypted = true;
+        let passphrase = "secret".to_owned();
+        encrypt_db(&url, &passphrase, preserve_unencrypted).unwrap();
+
+        assert!(path.exists());
+        assert_eq!(is_sqlite_encrypted_heuristics(&url), Some(true));
+
+        let backup_url: Url = format!("{url}.backup").parse().unwrap();
+        assert_eq!(is_sqlite_encrypted_heuristics(&backup_url), Some(false));
+
+        let _ = SqliteStorage::open(&url, Some(passphrase)).unwrap();
+
+        Ok(())
+    }
+}

--- a/src/storage/sql/mod.rs
+++ b/src/storage/sql/mod.rs
@@ -1,4 +1,5 @@
 mod encoding;
+mod encrypt;
 mod storage;
 mod util;
 


### PR DESCRIPTION
New configuration which enables encryption of the signal keystore and
the gurk messages database:

```toml 
passphrase = "secret" 
```

Previously unencrypted database is replaced by the encrypted one. Make
sure you backup your data before enabling this option.

After enabling encryption device has to be linked again.

Closes #6