### PR TITLE
feat: support for colored messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,18 @@
 # Changelog
 
+## 0.5.2-dev
+
+### Added
+
+- Add `colored_messages` config option
+
 ## 0.5.1
 
-## Added
+### Added
 
 - Edit messages ([#301])
 
-## Fixes
+### Fixes
 
 - Fix unexpected response HTTP 409 during linking ([#299])
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,6 +34,9 @@ pub struct Config {
     #[serde(default)]
     /// If set, enables encryption of the key store and messages database
     pub passphrase: Option<String>,
+    /// If set, the full message text will be colored, not only the author name
+    #[serde(default)]
+    pub colored_messages: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -73,6 +76,7 @@ impl Config {
             developer: Default::default(),
             sqlite: Default::default(),
             passphrase: None,
+            colored_messages: false,
         }
     }
 


### PR DESCRIPTION
This option is disabled by default, but can be enabled by setting the
`colored_messages` config option to `true`. The coloring is the same as
the one used for the author name.

Closes #285