### PR TITLE
feat: handle read notifications from other clients

### DIFF
--- a/.sqlx/query-1b6fc3cd9b2c351443f980ab3212bfce367a7cfc86201ddf11e25f18a9c8cdb2.json
+++ b/.sqlx/query-1b6fc3cd9b2c351443f980ab3212bfce367a7cfc86201ddf11e25f18a9c8cdb2.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                    SELECT\n                        m.channel_id AS \"channel_id: _\"\n                    FROM messages AS m\n                    WHERE m.arrived_at = ?\n                    LIMIT 1\n                ",
+  "describe": {
+    "columns": [
+      {
+        "name": "channel_id: _",
+        "ordinal": 0,
+        "type_info": "Blob"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "1b6fc3cd9b2c351443f980ab3212bfce367a7cfc86201ddf11e25f18a9c8cdb2"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### Added
 
-- Add `colored_messages` config option
+- Add `colored_messages` config option ([#311])
+- Handle read receipts from other clients ([#312])
+
+[#311]: https://github.com/boxdot/gurk-rs/pull/311
+[#312]: https://github.com/boxdot/gurk-rs/pull/312
 
 ## 0.5.1
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -480,7 +480,7 @@ impl App {
     }
 
     pub async fn on_message(&mut self, content: Content) -> anyhow::Result<()> {
-        tracing::info!(?content, "incoming");
+        // tracing::info!(?content, "incoming");
 
         #[cfg(feature = "dev")]
         if self.config.developer.dump_raw_messages {
@@ -490,6 +490,10 @@ impl App {
         }
 
         let user_id = self.user_id;
+
+        if let ContentBody::SynchronizeMessage(SyncMessage { ref read, .. }) = content.body {
+            self.handle_read(read);
+        }
 
         let (channel_idx, message) = match (content.metadata, content.body) {
             // Private note message
@@ -1559,7 +1563,7 @@ fn add_emoji_from_sticker(body: &mut Option<String>, sticker: Option<Sticker>) {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
 
     use crate::config::User;
@@ -1570,7 +1574,7 @@ mod tests {
     use std::cell::RefCell;
     use std::rc::Rc;
 
-    fn test_app() -> (
+    pub(crate) fn test_app() -> (
         App,
         mpsc::UnboundedReceiver<Event>,
         Rc<RefCell<Vec<Message>>>,

--- a/src/storage/forgetful.rs
+++ b/src/storage/forgetful.rs
@@ -65,4 +65,8 @@ impl Storage for ForgetfulStorage {
     }
 
     fn save(&mut self) {}
+
+    fn message_channel(&self, _arrived_at: u64) -> Option<ChannelId> {
+        None
+    }
 }

--- a/src/storage/memcache.rs
+++ b/src/storage/memcache.rs
@@ -172,4 +172,9 @@ impl<S: Storage> Storage for MemCache<S> {
     fn save(&mut self) {
         self.storage.save();
     }
+
+    fn message_channel(&self, arrived_at: u64) -> Option<ChannelId> {
+        // message arrived_at to channel_id conversion is not cached
+        self.storage.message_channel(arrived_at)
+    }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -44,6 +44,8 @@ pub trait Storage {
     /// Gets the message by id
     fn message(&self, message_id: MessageId) -> Option<Cow<Message>>;
 
+    fn message_channel(&self, arrived_at: u64) -> Option<ChannelId>;
+
     fn edits(
         &self,
         message_id: MessageId,


### PR DESCRIPTION
The unread channel counters are now updated when a read notification is recieved from another client.

Note that the counters are ephemeral and will be reset when the app is restarted.

Marking a channel as read in Gurk does not update the unread counters in other clients yet.

Related to #286