### PR TITLE
upgrade libsignal-client 0.51.1 -> 0.56.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2241,7 +2241,7 @@ dependencies = [
 [[package]]
 name = "libsignal-service"
 version = "0.1.0"
-source = "git+https://github.com/whisperfish/libsignal-service-rs?rev=5470ce6a2#5470ce6a272416d8274cd273017cc14bdbf2568e"
+source = "git+https://github.com/whisperfish/libsignal-service-rs?rev=f99ff8324378ea653dbd5aa0c5d55e4414b34e23#f99ff8324378ea653dbd5aa0c5d55e4414b34e23"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2276,7 +2276,7 @@ dependencies = [
 [[package]]
 name = "libsignal-service-hyper"
 version = "0.1.0"
-source = "git+https://github.com/whisperfish/libsignal-service-rs?rev=5470ce6a2#5470ce6a272416d8274cd273017cc14bdbf2568e"
+source = "git+https://github.com/whisperfish/libsignal-service-rs?rev=f99ff8324378ea653dbd5aa0c5d55e4414b34e23#f99ff8324378ea653dbd5aa0c5d55e4414b34e23"
 dependencies = [
  "async-trait",
  "async-tungstenite",
@@ -3246,7 +3246,7 @@ checksum = "94e851c7654eed9e68d7d27164c454961a616cf8c203d500607ef22c737b51bb"
 [[package]]
 name = "presage"
 version = "0.6.2"
-source = "git+https://github.com/whisperfish/presage?rev=c5cb55f7dee55f4ba344dde570c62d289ced58a7#c5cb55f7dee55f4ba344dde570c62d289ced58a7"
+source = "git+https://github.com/whisperfish/presage?rev=464626aa27829bc4d641086359afccdb0da4711f#464626aa27829bc4d641086359afccdb0da4711f"
 dependencies = [
  "base64 0.22.1",
  "futures",
@@ -3266,7 +3266,7 @@ dependencies = [
 [[package]]
 name = "presage-store-cipher"
 version = "0.1.0"
-source = "git+https://github.com/whisperfish/presage?rev=c5cb55f7dee55f4ba344dde570c62d289ced58a7#c5cb55f7dee55f4ba344dde570c62d289ced58a7"
+source = "git+https://github.com/whisperfish/presage?rev=464626aa27829bc4d641086359afccdb0da4711f#464626aa27829bc4d641086359afccdb0da4711f"
 dependencies = [
  "blake3",
  "chacha20poly1305",
@@ -3283,7 +3283,7 @@ dependencies = [
 [[package]]
 name = "presage-store-sled"
 version = "0.6.0-dev"
-source = "git+https://github.com/whisperfish/presage?rev=c5cb55f7dee55f4ba344dde570c62d289ced58a7#c5cb55f7dee55f4ba344dde570c62d289ced58a7"
+source = "git+https://github.com/whisperfish/presage?rev=464626aa27829bc4d641086359afccdb0da4711f#464626aa27829bc4d641086359afccdb0da4711f"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ debug = true
 dev = ["prost", "base64"]
 
 [dependencies]
-presage = { git = "https://github.com/whisperfish/presage", rev = "c5cb55f7dee55f4ba344dde570c62d289ced58a7" }
-presage-store-sled = { git = "https://github.com/whisperfish/presage", rev = "c5cb55f7dee55f4ba344dde570c62d289ced58a7" }
+presage = { git = "https://github.com/whisperfish/presage", rev = "464626aa27829bc4d641086359afccdb0da4711f" }
+presage-store-sled = { git = "https://github.com/whisperfish/presage", rev = "464626aa27829bc4d641086359afccdb0da4711f" }
 
 # dev feature dependencies
 prost = { version = "0.13.0", optional = true }


### PR DESCRIPTION
Not tested yet (I had `openssl` issues when doing `cargo run` on Fedora 40).

Fixes #313 