### PR TITLE
Add command, window mode, and keybinding logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1700,6 +1700,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
+ "strum",
+ "strum_macros",
  "tempfile",
  "textwrap",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -918,6 +918,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f64009896348fc5af4222e9cf7d7d82a95a256c634ebcf61c53e4ea461422242"
 
 [[package]]
+name = "crokey"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520e83558f4c008ac06fa6a86e5c1d4357be6f994cce7434463ebcdaadf47bb1"
+dependencies = [
+ "crokey-proc_macros",
+ "crossterm",
+ "once_cell",
+ "serde",
+ "strict",
+]
+
+[[package]]
+name = "crokey-proc_macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "370956e708a1ce65fe4ac5bb7185791e0ece7485087f17736d54a23a0895049f"
+dependencies = [
+ "crossterm",
+ "proc-macro2",
+ "quote",
+ "strict",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1642,6 +1668,7 @@ dependencies = [
  "chrono",
  "clap",
  "criterion",
+ "crokey",
  "crossterm",
  "dirs",
  "emojis",
@@ -4282,6 +4309,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strict"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f42444fea5b87a39db4218d9422087e66a85d0e7a0963a439b07bcdf91804006"
 
 [[package]]
 name = "stringprep"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ uuid = { version = "1.2", features = ["v4"] }
 whoami = "1.2.3"
 url = "2.5.0"
 tempfile = "3.3.0"
+crokey = "1.1.0"
 
 [package.metadata.cargo-machete]
 # not used directly; brings sqlcipher capabilities to sqlite

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,8 @@ whoami = "1.2.3"
 url = "2.5.0"
 tempfile = "3.3.0"
 crokey = "1.1.0"
+strum_macros = "0.26.4"
+strum = { version = "0.26.3", features = ["derive"] }
 
 [package.metadata.cargo-machete]
 # not used directly; brings sqlcipher capabilities to sqlite

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ libraries that are not available on crates.io.
 
 # Key bindings
 
+## Default keybindings
+
 * App navigation
   * `f1` Toggle help panel.
   * `ctrl+c` Quit.
@@ -97,6 +99,67 @@ libraries that are not available on crates.io.
   * `ctrl+p` Open / close channel selection popup.
 * Clipboard
   * `alt+y` Copy selected message to clipboard.
+
+## Custom keybindings
+The default keybindings can be overwritten at startup by configuring
+keybindings in `gurk.toml` using the format `keybindings.<mode>.<keycombination> =
+"<command>"`. Valid commands are `anywhere`, `normal`, `message_selected`,
+`channel_modal`, `multiline`, and `help`. Valid key combination specifiers are e.g. `left,
+alt-j, ctrl-f, backspace, pagedown`. The default keybindings can be disabled by
+setting `default_keybindings = false`. An empty command removes an existing
+binding if it exists in the given mode. Configuration troubleshooted by running
+`gurk --verbose` and examining the resulting `gurk.log`.
+
+### Supported commands
+```
+help
+quit
+toggle_channel_modal
+toggle_multiline
+react
+move_text up|down character|word|line
+select_channel previous|next
+select_channel_modal previous|text
+select_message previous|next entry
+kill_line
+kill_whole_line
+kill_backward_line
+kill_word
+copy_message selected
+beginning_of_line
+end_of_line
+delete_character previous
+edit_message
+open_url
+```
+
+### Example configuration
+```toml
+default_keybindings = true
+
+[keybindings.anywhere]
+ctrl-c = ""
+ctrl-q = "quit"
+
+[keybindings.normal]
+ctrl-j = ""
+ctrl-k = "kill_line"
+ctrl-n = "select_channel next"
+ctrl-p = "select_channel previous"
+alt-c = "toggle_channel_modal"
+up = "select_message previous entry"
+down = "select_message next entry"
+
+[keybindings.channel_modal]
+ctrl-j = ""
+ctrl-k = ""
+ctrl-n = "select_channel_modal next"
+ctrl-p = "select_channel_modal previous"
+
+[keybindings.message_selected]
+alt-y = ""
+alt-w = "copy_message selected"
+```
 
 ## License
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,7 @@
 use crate::channels::SelectChannel;
 use crate::command::{
-    get_keybindings, Command, DirectionVertical, ModeKeybinding, MoveAmountText,
-    MoveAmountVisual, MoveDirection, Widget, WindowMode,
+    get_keybindings, Command, DirectionVertical, ModeKeybinding, MoveAmountText, MoveAmountVisual,
+    MoveDirection, Widget, WindowMode,
 };
 use crate::config::Config;
 use crate::data::{BodyRange, Channel, ChannelId, Message, TypingAction, TypingSet};

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,0 +1,378 @@
+use std::collections::HashMap;
+
+use crokey::KeyCombination;
+use serde::{Deserialize, Serialize};
+
+pub type KeybindingConfig = HashMap<KeyCombination, String>;
+pub type ModeKeybindingConfig = HashMap<WindowMode, KeybindingConfig>;
+pub type Keybinding = HashMap<KeyCombination, Command>;
+pub type ModeKeybinding = HashMap<WindowMode, Keybinding>;
+
+#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum MoveDirection {
+    Previous,
+    Next,
+}
+
+impl MoveDirection {
+    fn parse(dir: &str) -> Result<Self, CommandParseError> {
+        match dir {
+            "previous" => Ok(Self::Previous),
+            "next" => Ok(Self::Next),
+            _ => Err(CommandParseError::BadEnumArg {
+                arg: dir.to_string(),
+                accept: vec!["previous".into(), "next".into()],
+                optional: false,
+            }),
+        }
+    }
+}
+
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum MoveAmountText {
+    Character,
+    Word,
+    Line,
+    // Sentence,
+}
+
+impl MoveAmountText {
+    fn parse(amount: &str) -> Result<Self, CommandParseError> {
+        match amount {
+            "character" | "c" => Ok(Self::Character),
+            "word" | "w" => Ok(Self::Word),
+            "line" | "l" => Ok(Self::Line),
+            _ => Err(CommandParseError::BadEnumArg {
+                arg: amount.to_string(),
+                accept: vec!["character".into(), "word".into(), "line".into()],
+                optional: false,
+            }),
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum MoveAmountVisual {
+    Entry,
+    // HalfScreen,
+    // Screen,
+}
+
+impl MoveAmountVisual {
+    fn parse(amount: &str) -> Result<Self, CommandParseError> {
+        match amount {
+            "entry" => Ok(Self::Entry),
+            // "half_screen" => Ok(Self::HalfScreen),
+            // "screen" => Ok(Self::Screen),
+            _ => Err(CommandParseError::BadEnumArg {
+                arg: amount.to_string(),
+                accept: vec!["entry".into()],
+                optional: false,
+            }),
+        }
+    }
+}
+
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum MessageSelector {
+    Selected,
+    Marked,
+}
+
+impl MessageSelector {
+    fn parse(input: &str) -> Result<Self, CommandParseError> {
+        match input {
+            "selected" => Ok(Self::Selected),
+            "marked" => Ok(Self::Marked),
+            _ => Err(CommandParseError::BadEnumArg {
+                arg: input.to_string(),
+                accept: vec!["selected".into(), "marked".into()],
+                optional: false,
+            }),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, Copy)]
+#[serde(rename_all = "snake_case")]
+pub enum WindowMode {
+    Anywhere,
+    Help,
+    ChannelModal,
+    Multiline,
+    MessageSelected,
+    Normal,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum Command {
+    /// Toggle help panel
+    Help,
+    /// Quit application
+    Quit,
+    /// Open pop-up for selecting a channel
+    ToggleChannelModal,
+    /// Switch between single-line and multi-line modes.
+    ToggleMultiline,
+    /// Sends emoji from input line as reaction on selected message.
+    React,
+    /// Move forward/backward one character/word/line
+    MoveText(MoveDirection, MoveAmountText),
+    // MoveChannel(MoveDirectionVert, MoveAmountVisual),
+    /// Select next/previous channel in sidebar
+    SelectChannel(MoveDirection),
+    /// Select next/previous channel in channel modal
+    SelectChannelModal(MoveDirection),
+    /// Select next/previous message
+    SelectMessage(MoveDirection, MoveAmountVisual),
+    /// Delete to the end of the line.
+    KillLine,
+    /// Delete from the start to the end of the line.
+    KillWholeLine,
+    /// Delete to the start of the line.
+    KillBackwardLine,
+    /// Delete last word.
+    KillWord,
+    /// Copy selected message to clipboard
+    CopyMessage(MessageSelector),
+    /// Move cursor to the beginning of the text.
+    BeginningOfLine,
+    /// Move cursor the the end of the text.
+    EndOfLine,
+    /// Delete previous character.
+    DeleteCharacter(MoveDirection),
+    /// Edit selected message
+    EditMessage,
+    /// Try to open the first url in the selected message
+    OpenUrl,
+    // ReplyMessage,
+    // DeleteMessage,
+}
+
+#[derive(Clone, Debug)]
+pub enum CommandParseError {
+    NoSuchCommand {
+        cmd: String,
+    },
+    InsufficientArgs {
+        cmd: String,
+        hint: Option<String>,
+    },
+    BadEnumArg {
+        arg: String,
+        accept: Vec<String>,
+        optional: bool,
+    },
+    ArgParseError {
+        arg: String,
+        err: String,
+    },
+}
+
+pub fn parse(input: &str) -> Result<Command, CommandParseError> {
+    let words: Vec<_> = input.split_whitespace().collect();
+    use CommandParseError as E;
+
+    if let Some((cmd, args)) = words.split_first() {
+        match *cmd {
+            "help" => Ok(Command::Help),
+            "quit" => Ok(Command::Quit),
+            "toggle_channel_modal" => Ok(Command::ToggleChannelModal),
+            "react" => Ok(Command::React),
+            "move_text" => {
+                let usage = E::InsufficientArgs {
+                    cmd: cmd.to_string(),
+                    hint: Some("previous|next character|word|line".into()),
+                };
+                let &dir = args.first().ok_or(usage.clone())?;
+                let &amount = args.get(1).ok_or(usage)?;
+                let dir = MoveDirection::parse(dir)?;
+                let amount = MoveAmountText::parse(amount)?;
+                Ok(Command::MoveText(dir, amount))
+            }
+            // MoveDirectionVert, MoveAmountVisual
+            "select_channel" => {
+                let usage = E::InsufficientArgs {
+                    cmd: cmd.to_string(),
+                    hint: Some("previous|next".into()),
+                };
+                let &dir = args.first().ok_or(usage)?;
+                let dir = MoveDirection::parse(dir)?;
+                Ok(Command::SelectChannel(dir))
+            }
+            "select_channel_modal" => {
+                let usage = E::InsufficientArgs {
+                    cmd: cmd.to_string(),
+                    hint: Some("previous|next".into()),
+                };
+                let &dir = args.first().ok_or(usage)?;
+                let dir = MoveDirection::parse(dir)?;
+                Ok(Command::SelectChannelModal(dir))
+            }
+            "select_message" => {
+                let usage = E::InsufficientArgs {
+                    cmd: cmd.to_string(),
+                    hint: Some("previous|next entry".into()),
+                };
+                let &dir = args.first().ok_or(usage.clone())?;
+                let &amount = args.get(1).ok_or(usage)?;
+                let dir = MoveDirection::parse(dir)?;
+                let amount = MoveAmountVisual::parse(amount)?;
+                Ok(Command::SelectMessage(dir, amount))
+            }
+            "kill_line" => Ok(Command::KillLine),
+            "kill_whole_line" => Ok(Command::KillWholeLine),
+            "kill_backward_line" => Ok(Command::KillBackwardLine),
+            "kill_word" => Ok(Command::KillWord),
+            "copy_message" => Ok(Command::CopyMessage(MessageSelector::parse(
+                args.first().unwrap_or(&"selected"),
+            )?)),
+            "beginning_of_line" => Ok(Command::BeginningOfLine),
+            "end_of_line" => Ok(Command::EndOfLine),
+            "delete_character" => {
+                let usage = E::InsufficientArgs {
+                    cmd: cmd.to_string(),
+                    hint: Some("previous|next".into()),
+                };
+                let &dir = args.first().ok_or(usage.clone())?;
+                let dir = MoveDirection::parse(dir)?;
+                Ok(Command::DeleteCharacter(dir))
+            }
+            "edit_message" => Ok(Command::EditMessage),
+            "open_url" => Ok(Command::OpenUrl),
+            // "reply_message" => Ok(Command::ReplyMessage),
+            // "delete_message" => Ok(Command::DeleteMessage),
+            _ => Err(CommandParseError::NoSuchCommand {
+                cmd: cmd.to_string(),
+            }),
+        }
+    } else {
+        Err(CommandParseError::NoSuchCommand { cmd: input.into() })
+    }
+}
+
+pub const DEFAULT_KEYBINDINGS: &str = r#"
+[anywhere]
+F1 = "help"
+ctrl-c = "quit"
+
+[normal]
+ctrl-p = "toggle_channel_modal"
+ctrl-left = "move_text previous character"
+ctrl-right = "move_text next character"
+left = "move_text previous character"
+right = "move_text next character"
+alt-left = "move_text previous word"
+alt-right = "move_text next word"
+alt-up = "select_message previous entry"
+alt-down = "select_message next entry"
+alt-j = "select_message next entry"
+alt-k = "select_message previous entry"
+pagedown = "select_message next entry"
+pageup = "select_message previous entry"
+alt-f = "move_text next word"
+ctrl-f = "move_text next character"
+alt-b = "move_text previous word"
+ctrl-b = "move_text previous character"
+ctrl-u = "kill_backward_line"
+ctrl-w = "kill_word"
+ctrl-j = "select_channel next"
+ctrl-k = "select_channel previous"
+down = "select_channel next"
+up = "select_channel previous"
+alt-backspace = "kill_word"
+home = "beginning_of_line"
+ctrl-a = "beginning_of_line"
+end = "end_of_line"
+ctrl-e = "end_of_line"
+backspace = "delete_character previous"
+tab = "react"
+
+[message_selected]
+alt-y = "copy_message selected"
+ctrl-e = "edit_message"
+
+[channel_modal]
+down = "select_channel_modal next"
+up = "select_channel_modal previous"
+ctrl-j = "select_channel_modal next"
+ctrl-k = "select_channel_modal previous"
+
+[multiline]
+down = "move_text next line"
+up = "move_text previous line"
+ctrl-j = "move_text next line"
+ctrl-k = "move_text previous line"
+
+[help]
+"#;
+
+#[cfg(test)]
+mod tests {
+    use toml;
+
+    use super::{get_keybindings, ModeKeybindingConfig, DEFAULT_KEYBINDINGS};
+
+    #[test]
+    fn default_keybindings_deserialize() {
+        let _keybindings: ModeKeybindingConfig = toml::from_str(DEFAULT_KEYBINDINGS).unwrap();
+    }
+
+    #[test]
+    fn default_keybindings_parse() {
+        get_keybindings(&ModeKeybindingConfig::new(), true).unwrap();
+    }
+
+    #[test]
+    fn custom_keybindings() {
+        let bindings: ModeKeybindingConfig =
+            toml::from_str("[normal]\n  F1 = \"\"\n  ctrl-h = \"help\"\n").unwrap();
+        get_keybindings(&bindings, true).unwrap();
+        get_keybindings(&bindings, false).unwrap();
+    }
+}
+
+fn merge_keybinding_configs(mkb1: &mut ModeKeybindingConfig, mkb2: ModeKeybindingConfig) {
+    for (mode, kb2) in mkb2 {
+        mkb1.entry(mode).or_insert(HashMap::new()).extend(kb2);
+    }
+}
+
+pub fn get_keybindings(
+    keybinding_config: &ModeKeybindingConfig,
+    default_bindings: bool,
+) -> Result<ModeKeybinding, CommandParseError> {
+    let mut keybindings = if default_bindings {
+        toml::from_str(DEFAULT_KEYBINDINGS).unwrap()
+    } else {
+        HashMap::new()
+    };
+    merge_keybinding_configs(&mut keybindings, keybinding_config.clone());
+    parse_mode_keybindings(&keybindings)
+}
+
+fn parse_mode_keybindings(
+    mkbc: &ModeKeybindingConfig,
+) -> Result<ModeKeybinding, CommandParseError> {
+    let mut mode_keybindings = ModeKeybinding::new();
+    for (&mode, kbc) in mkbc {
+        mode_keybindings.insert(mode, parse_keybindings(kbc)?);
+    }
+    Ok(mode_keybindings)
+}
+
+fn parse_keybindings(kbc: &KeybindingConfig) -> Result<Keybinding, CommandParseError> {
+    let mut keybindings = Keybinding::new();
+    for (&k, cmd) in kbc {
+        // Allows removing bindings
+        if !cmd.trim().is_empty() {
+            keybindings.insert(k, parse(cmd)?);
+        }
+    }
+    Ok(keybindings)
+}

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,103 +1,132 @@
 use std::collections::HashMap;
+use std::str::FromStr;
 
 use crokey::KeyCombination;
 use serde::{Deserialize, Serialize};
+use strum::{EnumIter, EnumProperty, EnumString, VariantNames};
 
 pub type KeybindingConfig = HashMap<KeyCombination, String>;
 pub type ModeKeybindingConfig = HashMap<WindowMode, KeybindingConfig>;
 pub type Keybinding = HashMap<KeyCombination, Command>;
 pub type ModeKeybinding = HashMap<WindowMode, Keybinding>;
 
-#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
-#[serde(rename_all = "snake_case")]
+#[derive(
+    Clone,
+    Default,
+    Debug,
+    Eq,
+    PartialEq,
+    strum_macros::Display,
+    strum_macros::VariantNames,
+    EnumString,
+)]
+#[strum(serialize_all = "snake_case")]
+pub enum Widget {
+    #[default]
+    Help,
+}
+
+#[derive(
+    Clone,
+    Default,
+    Debug,
+    Eq,
+    PartialEq,
+    strum_macros::Display,
+    strum_macros::VariantNames,
+    EnumString,
+)]
+#[strum(serialize_all = "snake_case")]
+pub enum DirectionVertical {
+    #[default]
+    Up,
+    Down,
+}
+
+#[derive(
+    Clone,
+    Default,
+    Debug,
+    Eq,
+    PartialEq,
+    strum_macros::Display,
+    strum_macros::VariantNames,
+    EnumString,
+)]
+#[strum(serialize_all = "snake_case")]
 pub enum MoveDirection {
+    #[default]
     Previous,
     Next,
 }
 
-impl MoveDirection {
-    fn parse(dir: &str) -> Result<Self, CommandParseError> {
-        match dir {
-            "previous" => Ok(Self::Previous),
-            "next" => Ok(Self::Next),
-            _ => Err(CommandParseError::BadEnumArg {
-                arg: dir.to_string(),
-                accept: vec!["previous".into(), "next".into()],
-                optional: false,
-            }),
-        }
-    }
-}
-
-#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
-#[serde(rename_all = "snake_case")]
+#[derive(
+    Clone,
+    Default,
+    Debug,
+    Eq,
+    PartialEq,
+    strum_macros::Display,
+    strum_macros::VariantNames,
+    EnumString,
+)]
+#[strum(serialize_all = "snake_case")]
 pub enum MoveAmountText {
+    #[default]
     Character,
     Word,
     Line,
     // Sentence,
 }
 
-impl MoveAmountText {
-    fn parse(amount: &str) -> Result<Self, CommandParseError> {
-        match amount {
-            "character" | "c" => Ok(Self::Character),
-            "word" | "w" => Ok(Self::Word),
-            "line" | "l" => Ok(Self::Line),
-            _ => Err(CommandParseError::BadEnumArg {
-                arg: amount.to_string(),
-                accept: vec!["character".into(), "word".into(), "line".into()],
-                optional: false,
-            }),
-        }
-    }
-}
-
-#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
-#[serde(rename_all = "snake_case")]
+#[derive(
+    Clone,
+    Default,
+    Debug,
+    Eq,
+    PartialEq,
+    strum_macros::Display,
+    strum_macros::VariantNames,
+    EnumString,
+)]
+#[strum(serialize_all = "snake_case")]
 pub enum MoveAmountVisual {
+    #[default]
     Entry,
     // HalfScreen,
     // Screen,
 }
 
-impl MoveAmountVisual {
-    fn parse(amount: &str) -> Result<Self, CommandParseError> {
-        match amount {
-            "entry" => Ok(Self::Entry),
-            // "half_screen" => Ok(Self::HalfScreen),
-            // "screen" => Ok(Self::Screen),
-            _ => Err(CommandParseError::BadEnumArg {
-                arg: amount.to_string(),
-                accept: vec!["entry".into()],
-                optional: false,
-            }),
-        }
-    }
-}
-
-#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
-#[serde(rename_all = "snake_case")]
+#[derive(
+    Clone,
+    Default,
+    Debug,
+    Eq,
+    PartialEq,
+    strum_macros::Display,
+    strum_macros::VariantNames,
+    EnumString,
+)]
+#[strum(serialize_all = "snake_case")]
 pub enum MessageSelector {
+    #[default]
     Selected,
     Marked,
 }
 
-impl MessageSelector {
-    fn parse(input: &str) -> Result<Self, CommandParseError> {
-        match input {
-            "selected" => Ok(Self::Selected),
-            "marked" => Ok(Self::Marked),
-            _ => Err(CommandParseError::BadEnumArg {
-                arg: input.to_string(),
-                accept: vec!["selected".into(), "marked".into()],
-                optional: false,
-            }),
-        }
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, Copy)]
+#[derive(
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Deserialize,
+    Serialize,
+    Hash,
+    Copy,
+    strum_macros::Display,
+    strum_macros::VariantNames,
+)]
+#[strum(serialize_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 pub enum WindowMode {
     Anywhere,
@@ -108,47 +137,87 @@ pub enum WindowMode {
     Normal,
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
-#[serde(rename_all = "snake_case")]
+#[derive(
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    strum_macros::Display,
+    strum_macros::VariantNames,
+    EnumString,
+    EnumIter,
+    EnumProperty,
+)]
+#[strum(serialize_all = "snake_case")]
 pub enum Command {
-    /// Toggle help panel
+    #[strum(props(desc = "Toggle help panel"))]
     Help,
-    /// Quit application
+    #[strum(props(desc = "Quit application"))]
     Quit,
-    /// Open pop-up for selecting a channel
+    #[strum(props(desc = "Open pop-up for selecting a channel"))]
     ToggleChannelModal,
-    /// Switch between single-line and multi-line modes.
+    #[strum(props(desc = "Switch between single-line and multi-line modes."))]
     ToggleMultiline,
-    /// Sends emoji from input line as reaction on selected message.
+    #[strum(props(desc = "Sends emoji from input line as reaction on selected message."))]
     React,
-    /// Move forward/backward one character/word/line
+    #[strum(props(desc = "Scroll a widget", usage = "scroll help up|down entry"))]
+    #[strum(serialize = "scroll", to_string = "scroll {0} {1} {2}")]
+    Scroll(Widget, DirectionVertical, MoveAmountVisual),
+    #[strum(props(
+        desc = "Move forward/backward one character/word/line",
+        usage = "move_text previous|next character|word|line"
+    ))]
+    #[strum(serialize = "move_text", to_string = "move_text {0} {1}")]
     MoveText(MoveDirection, MoveAmountText),
     // MoveChannel(MoveDirectionVert, MoveAmountVisual),
-    /// Select next/previous channel in sidebar
+    #[strum(props(
+        desc = "Select next/previous channel in sidebar",
+        usage = "select_channel previous|next"
+    ))]
+    #[strum(serialize = "select_channel", to_string = "select_channel {0}")]
     SelectChannel(MoveDirection),
-    /// Select next/previous channel in channel modal
+    #[strum(props(
+        desc = "Select next/previous channel in channel modal",
+        usage = "select_channel_modal previous|next"
+    ))]
+    #[strum(
+        serialize = "select_channel_modal",
+        to_string = "select_channel_modal {0}"
+    )]
     SelectChannelModal(MoveDirection),
-    /// Select next/previous message
+    #[strum(props(
+        desc = "Select next/previous message",
+        usage = "select_message previous|next entry"
+    ))]
+    #[strum(serialize = "select_message", to_string = "select_message {0} {1}")]
     SelectMessage(MoveDirection, MoveAmountVisual),
-    /// Delete to the end of the line.
+    #[strum(props(desc = "Delete to the end of the line."))]
     KillLine,
-    /// Delete from the start to the end of the line.
+    #[strum(props(desc = "Delete from the start to the end of the line."))]
     KillWholeLine,
-    /// Delete to the start of the line.
+    #[strum(props(desc = "Delete to the start of the line."))]
     KillBackwardLine,
-    /// Delete last word.
+    #[strum(props(desc = "Delete last word."))]
     KillWord,
-    /// Copy selected message to clipboard
+    #[strum(props(
+        desc = "Copy selected message to clipboard",
+        usage = "copy_message selected"
+    ))]
+    #[strum(serialize = "copy_message", to_string = "copy_message {0}")]
     CopyMessage(MessageSelector),
-    /// Move cursor to the beginning of the text.
+    #[strum(props(desc = "Move cursor to the beginning of the text."))]
     BeginningOfLine,
-    /// Move cursor the the end of the text.
+    #[strum(props(desc = "Move cursor the the end of the text."))]
     EndOfLine,
-    /// Delete previous character.
+    #[strum(props(
+        desc = "Delete previous character.",
+        usage = "delete_character previous|next"
+    ))]
+    #[strum(serialize = "delete_character", to_string = "delete_character {0}")]
     DeleteCharacter(MoveDirection),
-    /// Edit selected message
+    #[strum(props(desc = "Edit selected message"))]
     EditMessage,
-    /// Try to open the first url in the selected message
+    #[strum(props(desc = "Try to open the first url in the selected message"))]
     OpenUrl,
     // ReplyMessage,
     // DeleteMessage,
@@ -158,6 +227,7 @@ pub enum Command {
 pub enum CommandParseError {
     NoSuchCommand {
         cmd: String,
+        accept: &'static [&'static str],
     },
     InsufficientArgs {
         cmd: String,
@@ -165,95 +235,121 @@ pub enum CommandParseError {
     },
     BadEnumArg {
         arg: String,
-        accept: Vec<String>,
+        accept: &'static [&'static str],
         optional: bool,
-    },
-    ArgParseError {
-        arg: String,
-        err: String,
     },
 }
 
-pub fn parse(input: &str) -> Result<Command, CommandParseError> {
-    let words: Vec<_> = input.split_whitespace().collect();
+fn parse(input: &str) -> Result<Command, CommandParseError> {
+    let words: Vec<_> = input.trim().split_whitespace().collect();
     use CommandParseError as E;
 
-    if let Some((cmd, args)) = words.split_first() {
-        match *cmd {
-            "help" => Ok(Command::Help),
-            "quit" => Ok(Command::Quit),
-            "toggle_channel_modal" => Ok(Command::ToggleChannelModal),
-            "toggle_multiline" => Ok(Command::ToggleMultiline),
-            "react" => Ok(Command::React),
-            "move_text" => {
-                let usage = E::InsufficientArgs {
-                    cmd: cmd.to_string(),
-                    hint: Some("previous|next character|word|line".into()),
-                };
-                let &dir = args.first().ok_or(usage.clone())?;
-                let &amount = args.get(1).ok_or(usage)?;
-                let dir = MoveDirection::parse(dir)?;
-                let amount = MoveAmountText::parse(amount)?;
-                Ok(Command::MoveText(dir, amount))
-            }
-            // MoveDirectionVert, MoveAmountVisual
-            "select_channel" => {
-                let usage = E::InsufficientArgs {
-                    cmd: cmd.to_string(),
-                    hint: Some("previous|next".into()),
-                };
-                let &dir = args.first().ok_or(usage)?;
-                let dir = MoveDirection::parse(dir)?;
-                Ok(Command::SelectChannel(dir))
-            }
-            "select_channel_modal" => {
-                let usage = E::InsufficientArgs {
-                    cmd: cmd.to_string(),
-                    hint: Some("previous|next".into()),
-                };
-                let &dir = args.first().ok_or(usage)?;
-                let dir = MoveDirection::parse(dir)?;
-                Ok(Command::SelectChannelModal(dir))
-            }
-            "select_message" => {
-                let usage = E::InsufficientArgs {
-                    cmd: cmd.to_string(),
-                    hint: Some("previous|next entry".into()),
-                };
-                let &dir = args.first().ok_or(usage.clone())?;
-                let &amount = args.get(1).ok_or(usage)?;
-                let dir = MoveDirection::parse(dir)?;
-                let amount = MoveAmountVisual::parse(amount)?;
-                Ok(Command::SelectMessage(dir, amount))
-            }
-            "kill_line" => Ok(Command::KillLine),
-            "kill_whole_line" => Ok(Command::KillWholeLine),
-            "kill_backward_line" => Ok(Command::KillBackwardLine),
-            "kill_word" => Ok(Command::KillWord),
-            "copy_message" => Ok(Command::CopyMessage(MessageSelector::parse(
-                args.first().unwrap_or(&"selected"),
-            )?)),
-            "beginning_of_line" => Ok(Command::BeginningOfLine),
-            "end_of_line" => Ok(Command::EndOfLine),
-            "delete_character" => {
-                let usage = E::InsufficientArgs {
-                    cmd: cmd.to_string(),
-                    hint: Some("previous|next".into()),
-                };
-                let &dir = args.first().ok_or(usage.clone())?;
-                let dir = MoveDirection::parse(dir)?;
-                Ok(Command::DeleteCharacter(dir))
-            }
-            "edit_message" => Ok(Command::EditMessage),
-            "open_url" => Ok(Command::OpenUrl),
-            // "reply_message" => Ok(Command::ReplyMessage),
-            // "delete_message" => Ok(Command::DeleteMessage),
-            _ => Err(CommandParseError::NoSuchCommand {
-                cmd: cmd.to_string(),
-            }),
+    let (cmd_str, args) = words.split_first().unwrap();
+    let cmd = Command::from_str(cmd_str).map_err(|_e| E::NoSuchCommand {
+        cmd: cmd_str.to_string(),
+        accept: Command::VARIANTS,
+    })?;
+    match cmd {
+        Command::Scroll(_, _, _) => {
+            let usage = E::InsufficientArgs {
+                cmd: cmd_str.to_string(),
+                hint: Some(
+                    [
+                        Widget::VARIANTS.join("|"),
+                        DirectionVertical::VARIANTS.join("|"),
+                        MoveAmountVisual::VARIANTS.join("|"),
+                    ]
+                    .join(" "),
+                ),
+            };
+            let widget = args.first().ok_or(usage.clone())?;
+            let dir = args.get(1).ok_or(usage.clone())?;
+            let amount = args.get(2).ok_or(usage)?;
+            let widget = Widget::from_str(widget).map_err(|_e| E::BadEnumArg {
+                arg: widget.to_string(),
+                accept: Widget::VARIANTS,
+                optional: false,
+            })?;
+            let dir = DirectionVertical::from_str(dir).map_err(|_e| E::BadEnumArg {
+                arg: dir.to_string(),
+                accept: DirectionVertical::VARIANTS,
+                optional: false,
+            })?;
+            let amount = MoveAmountVisual::from_str(amount).map_err(|_e| E::BadEnumArg {
+                arg: amount.to_string(),
+                accept: MoveAmountVisual::VARIANTS,
+                optional: false,
+            })?;
+            Ok(Command::Scroll(widget, dir, amount))
         }
-    } else {
-        Err(CommandParseError::NoSuchCommand { cmd: input.into() })
+        Command::MoveText(_, _) => {
+            let usage = E::InsufficientArgs {
+                cmd: cmd_str.to_string(),
+                hint: Some(
+                    [
+                        MoveDirection::VARIANTS.join("|"),
+                        MoveAmountText::VARIANTS.join("|"),
+                    ]
+                    .join(" "),
+                ),
+            };
+            let direction = args.first().ok_or(usage.clone())?;
+            let amount = args.get(1).ok_or(usage)?;
+            let direction = MoveDirection::from_str(direction).map_err(|_e| E::BadEnumArg {
+                arg: direction.to_string(),
+                accept: MoveDirection::VARIANTS,
+                optional: false,
+            })?;
+            let amount = MoveAmountText::from_str(amount).map_err(|_e| E::BadEnumArg {
+                arg: amount.to_string(),
+                accept: MoveAmountText::VARIANTS,
+                optional: false,
+            })?;
+            Ok(Command::MoveText(direction, amount))
+        }
+        Command::SelectChannel(_) => {
+            let usage = E::InsufficientArgs {
+                cmd: cmd_str.to_string(),
+                hint: Some(MoveDirection::VARIANTS.join("|")),
+            };
+            let direction = args.first().ok_or(usage)?;
+            let direction = MoveDirection::from_str(direction).map_err(|_e| E::BadEnumArg {
+                arg: direction.to_string(),
+                accept: MoveDirection::VARIANTS,
+                optional: false,
+            })?;
+            Ok(Command::SelectChannel(direction))
+            // Ok(Command::SelectChannel(MoveDirection::from_str(args.first().unwrap_or(&""))?))
+        }
+        Command::SelectChannelModal(_) => {
+            let usage = E::InsufficientArgs {
+                cmd: cmd_str.to_string(),
+                hint: Some(MoveDirection::VARIANTS.join("|")),
+            };
+            let direction = args.first().ok_or(usage)?;
+            let direction = MoveDirection::from_str(direction).map_err(|_e| E::BadEnumArg {
+                arg: direction.to_string(),
+                accept: MoveDirection::VARIANTS,
+                optional: false,
+            })?;
+            Ok(Command::SelectChannelModal(direction))
+            // Ok(Command::SelectChannelModal(MoveDirection::from_str(args.first().unwrap_or(&""))?))
+        }
+        Command::CopyMessage(_) => {
+            let usage = E::InsufficientArgs {
+                cmd: cmd_str.to_string(),
+                hint: Some(MessageSelector::VARIANTS.join("|")),
+            };
+            let selector = args.first().ok_or(usage)?;
+            let selector = MessageSelector::from_str(selector).map_err(|_e| E::BadEnumArg {
+                arg: selector.to_string(),
+                accept: MessageSelector::VARIANTS,
+                optional: false,
+            })?;
+            Ok(Command::CopyMessage(selector))
+            // Ok(Command::CopyMessage(MessageSelector::from_str(args.first().unwrap_or(&""))?))
+        }
+        _ => Ok(cmd),
     }
 }
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -183,6 +183,7 @@ pub fn parse(input: &str) -> Result<Command, CommandParseError> {
             "help" => Ok(Command::Help),
             "quit" => Ok(Command::Quit),
             "toggle_channel_modal" => Ok(Command::ToggleChannelModal),
+            "toggle_multiline" => Ok(Command::ToggleMultiline),
             "react" => Ok(Command::React),
             "move_text" => {
                 let usage = E::InsufficientArgs {
@@ -263,6 +264,7 @@ ctrl-c = "quit"
 
 [normal]
 ctrl-p = "toggle_channel_modal"
+alt-enter = "toggle_multiline"
 ctrl-left = "move_text previous character"
 ctrl-right = "move_text next character"
 left = "move_text previous character"

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,8 @@ use url::Url;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use crate::command::ModeKeybindingConfig;
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Config {
     /// Path to the JSON file (incl. filename) storing channels and messages.
@@ -37,6 +39,12 @@ pub struct Config {
     /// If set, the full message text will be colored, not only the author name
     #[serde(default)]
     pub colored_messages: bool,
+    #[serde(default)]
+    /// Keymaps
+    pub keybindings: ModeKeybindingConfig,
+    /// Whether to enable the default keybindings
+    #[serde(default = "default_true")]
+    pub default_keybindings: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -77,6 +85,8 @@ impl Config {
             sqlite: Default::default(),
             passphrase: None,
             colored_messages: false,
+            default_keybindings: true,
+            keybindings: ModeKeybindingConfig::default(),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod app;
 pub mod backoff;
 mod channels;
+pub mod command;
 pub mod config;
 pub mod cursor;
 pub mod data;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,14 +9,15 @@ use chrono::{DateTime, Utc};
 use clap::Parser;
 use crossterm::{
     event::{
-        DisableMouseCapture, EnableMouseCapture, Event as CEvent, EventStream, KeyCode, KeyEvent,
-        KeyEventKind, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
+        DisableMouseCapture, EnableMouseCapture, Event as CEvent, EventStream, KeyEvent,
+        KeyEventKind, MouseButton, MouseEvent, MouseEventKind,
     },
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
 use gurk::app::App;
 use gurk::backoff::Backoff;
+use gurk::command::Command;
 use gurk::storage::{sync_from_signal, JsonStorage, MemCache, SqliteStorage, Storage};
 use gurk::{config, signal, ui};
 use presage::libsignal_service::content::Content;
@@ -320,103 +321,17 @@ async fn run_single_threaded(relink: bool) -> anyhow::Result<()> {
                     kind: KeyEventKind::Press,
                     ..
                 },
-            )) => match event.code {
-                KeyCode::F(1u8) => {
-                    // Toggle help panel
-                    app.toggle_help();
-                }
-                KeyCode::Char('c') if event.modifiers.contains(KeyModifiers::CONTROL) => {
-                    break;
-                }
-                KeyCode::Left => {
-                    if event
-                        .modifiers
-                        .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
-                    {
-                        app.get_input().move_back_word();
+            )) => {
+                if let Some(cmd) = app.event_to_command(&event) {
+                    if *cmd == Command::Quit {
+                        break;
                     } else {
-                        app.get_input().on_left();
+                        app.on_command(cmd.clone()).await?;
                     }
+                } else {
+                    app.on_key(event).await?
                 }
-                KeyCode::Up if event.modifiers.contains(KeyModifiers::ALT) => app.on_pgup(),
-                KeyCode::Right => {
-                    if event
-                        .modifiers
-                        .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
-                    {
-                        app.get_input().move_forward_word();
-                    } else {
-                        app.get_input().on_right();
-                    }
-                }
-                KeyCode::Down if event.modifiers.contains(KeyModifiers::ALT) => app.on_pgdn(),
-                KeyCode::Char('j') if event.modifiers.contains(KeyModifiers::ALT) => app.on_pgdn(),
-                KeyCode::PageUp => app.on_pgup(),
-                KeyCode::Char('k') if event.modifiers.contains(KeyModifiers::ALT) => app.on_pgup(),
-                KeyCode::PageDown => app.on_pgdn(),
-                KeyCode::Char('f') if event.modifiers.contains(KeyModifiers::ALT) => {
-                    app.get_input().move_forward_word();
-                }
-                KeyCode::Char('b') if event.modifiers.contains(KeyModifiers::ALT) => {
-                    app.get_input().move_back_word();
-                }
-                KeyCode::Char('u') if event.modifiers.contains(KeyModifiers::CONTROL) => {
-                    app.get_input().on_delete_line();
-                }
-                KeyCode::Char('w') if event.modifiers.contains(KeyModifiers::CONTROL) => {
-                    app.get_input().on_delete_word();
-                }
-                KeyCode::Down => {
-                    if app.is_select_channel_shown() {
-                        app.select_channel_next()
-                    } else if app.is_multiline_input {
-                        app.input.move_line_down();
-                    } else {
-                        app.select_next_channel();
-                    }
-                }
-                KeyCode::Char('j') if event.modifiers.contains(KeyModifiers::CONTROL) => {
-                    if app.is_select_channel_shown() {
-                        app.select_channel_next()
-                    } else if app.is_multiline_input {
-                        app.input.move_line_down();
-                    } else {
-                        app.select_next_channel();
-                    }
-                }
-                KeyCode::Char('y') if event.modifiers.contains(KeyModifiers::ALT) => {
-                    app.copy_selection();
-                }
-                KeyCode::Up => {
-                    if app.is_select_channel_shown() {
-                        app.select_channel_prev()
-                    } else if app.is_multiline_input {
-                        app.input.move_line_up();
-                    } else {
-                        app.select_previous_channel();
-                    }
-                }
-                KeyCode::Char('k') if event.modifiers.contains(KeyModifiers::CONTROL) => {
-                    if app.is_select_channel_shown() {
-                        app.select_channel_prev()
-                    } else if app.is_multiline_input {
-                        app.input.move_line_up();
-                    } else {
-                        app.select_previous_channel();
-                    }
-                }
-                KeyCode::Backspace
-                    if event
-                        .modifiers
-                        .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
-                {
-                    app.get_input().on_delete_word();
-                }
-                KeyCode::Char('k') if event.modifiers.contains(KeyModifiers::CONTROL) => {
-                    app.get_input().on_delete_suffix();
-                }
-                _ => app.on_key(event).await?,
-            },
+            }
             Some(Event::Input(..)) => {}
             Some(Event::Paste(content)) => {
                 let multi_line_state = app.is_multiline_input;

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,6 @@ use crossterm::{
 };
 use gurk::app::App;
 use gurk::backoff::Backoff;
-use gurk::command::Command;
 use gurk::storage::{sync_from_signal, JsonStorage, MemCache, SqliteStorage, Storage};
 use gurk::{config, signal, ui};
 use presage::libsignal_service::content::Content;
@@ -321,17 +320,7 @@ async fn run_single_threaded(relink: bool) -> anyhow::Result<()> {
                     kind: KeyEventKind::Press,
                     ..
                 },
-            )) => {
-                if let Some(cmd) = app.event_to_command(&event) {
-                    if *cmd == Command::Quit {
-                        break;
-                    } else {
-                        app.on_command(cmd.clone()).await?;
-                    }
-                } else {
-                    app.on_key(event).await?
-                }
-            }
+            )) => app.on_key(event).await?,
             Some(Event::Input(..)) => {}
             Some(Event::Paste(content)) => {
                 let multi_line_state = app.is_multiline_input;

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -701,7 +701,8 @@ fn draw_help(f: &mut Frame, app: &mut App, area: Rect) {
             )
         })
         .join("\n");
-    let commands = Paragraph::new(commands + "\n" + &mode_shortcuts).block(Block::bordered().title("Available commands and configured shortcuts"));
+    let commands = Paragraph::new(commands + "\n" + &mode_shortcuts)
+        .block(Block::bordered().title("Available commands and configured shortcuts"));
     f.render_widget(commands, area);
 }
 


### PR DESCRIPTION
Most hardcoded shortcuts were replaced with a mode-dependent configurable shortcuts, which are mapped to abstract commands handled for easier handling.

The concept of window modes was introduced to allow conditioning bindings on e.g. whether the help mode is active or whether a message is selected. Most bindings were moved to `WindowMode.Normal`, which has the lowest priority and does not get considered when the help popup or the channel modal is shown. `WindowMode.Anywhere` takes precedence over all other modes. The remaining modes are usually inserted in between if they are active (`Multiline, MessageSelected, Normal`).

Keybindings are serialised from toml at startup. The default keybinding is active by default and can be overwritten via the configuration, e.g.

```toml
default_keybindings = true
[keybinding.anywhere]
ctrl-c = ""
ctrl-q = "quit"
```

Suggested tasks
- [x] Show configured keybindings in the help menu
- [x] List all commands in the help menu
- [ ] Allow scrolling in the help menu: I'm not sure whether the widgets should be exposed in `App` or if there's a better way
- [ ] Add default keybindings for scrolling the help menu
- [ ] Enhance structure of help screen
- [ ] Update commands and keybindings in `README.md`
- [ ] Consume key events while in help mode to prevent simple key presses or `Enter` to be passed through

I'd appreciate your feedback on these changes.