### PR TITLE
Command bindings followup

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ libraries that are not available on crates.io.
   * `ctrl+p` Open / close channel selection popup.
 * Clipboard
   * `alt+y` Copy selected message to clipboard.
+* Help menu
+  * `ctrl+j / Up / PgUp` Previous line
+  * `ctrl+k / Down / PgDown` Next line
 
 ## Custom keybindings
 The default keybindings can be overwritten at startup by configuring
@@ -117,7 +120,8 @@ quit
 toggle_channel_modal
 toggle_multiline
 react
-move_text up|down character|word|line
+scroll help up|down entry
+move_text previous|next character|word|line
 select_channel previous|next
 select_channel_modal previous|text
 select_message previous|next entry

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ libraries that are not available on crates.io.
   * `ctrl+a / Home` Move cursor to the beginning of the line.
   * `ctrl+e / End` Move cursor the the end of the line.
 * Message/channel selection
-  * `Esc` Reset message selection.
+  * `esc` Reset message selection or close channel selection popup.
   * `alt+Up / alt+k / PgUp` Select previous message.
   * `alt+Down / alt+j / PgDown` Select next message.
   * `ctrl+j / Up` Select previous channel.
@@ -100,6 +100,7 @@ libraries that are not available on crates.io.
 * Clipboard
   * `alt+y` Copy selected message to clipboard.
 * Help menu
+  * `esc` Close help panel.
   * `ctrl+j / Up / PgUp` Previous line
   * `ctrl+k / Down / PgDown` Next line
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -341,9 +341,7 @@ impl App {
                     }
                 }
                 KeyCode::Esc => {
-                    if self.select_channel.is_shown {
-                        self.select_channel.is_shown = false;
-                    } else if !self.reset_editing() {
+                    if !self.reset_editing() {
                         self.reset_message_selection();
                     }
                 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -59,7 +59,7 @@ pub struct App {
     pub storage: Box<dyn Storage>,
     pub channels: StatefulList<ChannelId>,
     pub messages: BTreeMap<ChannelId, StatefulList<u64 /* arrived at*/>>,
-    pub help_scroll: u64,
+    pub help_scroll: (u16, u16),
     pub user_id: Uuid,
     pub should_quit: bool,
     url_regex: LazyRegex,
@@ -123,7 +123,7 @@ impl App {
             storage,
             channels,
             messages,
-            help_scroll: 0,
+            help_scroll: (0, 0),
             should_quit: false,
             url_regex: LazyRegex::new(URL_REGEX),
             attachment_regex: LazyRegex::new(ATTACHMENT_REGEX),
@@ -295,14 +295,13 @@ impl App {
                 self.should_quit = true;
             }
             Command::Scroll(Widget::Help, DirectionVertical::Up, MoveAmountVisual::Entry) => {
-                // TODO: rerender
-                if self.help_scroll >= 1 {
-                    self.help_scroll -= 1
+                if self.help_scroll.0 >= 1 {
+                    self.help_scroll.0 -= 1
                 }
             }
             Command::Scroll(Widget::Help, DirectionVertical::Down, MoveAmountVisual::Entry) => {
-                // TODO: rerender
-                self.help_scroll += 1
+                // TODO: prevent overscrolling
+                self.help_scroll.0 += 1
             }
         }
         Ok(())

--- a/src/app.rs
+++ b/src/app.rs
@@ -303,6 +303,7 @@ impl App {
                 // TODO: prevent overscrolling
                 self.help_scroll.0 += 1
             }
+            Command::NoOp => {}
         }
         Ok(())
     }
@@ -1588,7 +1589,12 @@ impl App {
                 }
             }
         }
-        None
+        if self.is_help() {
+            // Swallow event
+            Some(&Command::NoOp)
+        } else {
+            None
+        }
     }
 }
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -150,6 +150,8 @@ pub enum WindowMode {
 )]
 #[strum(serialize_all = "snake_case")]
 pub enum Command {
+    #[strum(props(desc = "Do nothing"))]
+    NoOp,
     #[strum(props(desc = "Toggle help panel"))]
     Help,
     #[strum(props(desc = "Quit application"))]

--- a/src/command.rs
+++ b/src/command.rs
@@ -408,6 +408,12 @@ ctrl-j = "move_text next line"
 ctrl-k = "move_text previous line"
 
 [help]
+ctrl-j = "scroll help down entry"
+ctrl-k = "scroll help up entry"
+down = "scroll help down entry"
+up = "scroll help up entry"
+pagedown = "scroll help down entry"
+pageup = "scroll help up entry"
 "#;
 
 #[cfg(test)]

--- a/src/command.rs
+++ b/src/command.rs
@@ -335,6 +335,31 @@ fn parse(input: &str) -> Result<Command, CommandParseError> {
             Ok(Command::SelectChannelModal(direction))
             // Ok(Command::SelectChannelModal(MoveDirection::from_str(args.first().unwrap_or(&""))?))
         }
+        Command::SelectMessage(_, _) => {
+            let usage = E::InsufficientArgs {
+                cmd: cmd_str.to_string(),
+                hint: Some(
+                    [
+                        MoveDirection::VARIANTS.join("|"),
+                        MoveAmountVisual::VARIANTS.join("|"),
+                    ]
+                    .join(" "),
+                ),
+            };
+            let direction = args.first().ok_or(usage.clone())?;
+            let amount = args.get(1).ok_or(usage)?;
+            let direction = MoveDirection::from_str(direction).map_err(|_e| E::BadEnumArg {
+                arg: direction.to_string(),
+                accept: MoveDirection::VARIANTS,
+                optional: false,
+            })?;
+            let amount = MoveAmountVisual::from_str(amount).map_err(|_e| E::BadEnumArg {
+                arg: amount.to_string(),
+                accept: MoveAmountText::VARIANTS,
+                optional: false,
+            })?;
+            Ok(Command::SelectMessage(direction, amount))
+        }
         Command::CopyMessage(_) => {
             let usage = E::InsufficientArgs {
                 cmd: cmd_str.to_string(),

--- a/src/command.rs
+++ b/src/command.rs
@@ -421,6 +421,8 @@ alt-y = "copy_message selected"
 ctrl-e = "edit_message"
 
 [channel_modal]
+esc = "toggle_channel_modal"
+ctrl-p = "toggle_channel_modal"
 down = "select_channel_modal next"
 up = "select_channel_modal previous"
 ctrl-j = "select_channel_modal next"
@@ -433,6 +435,7 @@ ctrl-j = "move_text next line"
 ctrl-k = "move_text previous line"
 
 [help]
+esc = "help"
 ctrl-j = "scroll help down entry"
 ctrl-k = "scroll help up entry"
 down = "scroll help down entry"

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use chrono::Datelike;
 use itertools::Itertools;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
-use ratatui::style::{Color, Style};
+use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{Block, Borders, Clear, List, ListDirection, ListItem, Paragraph};
 use ratatui::Frame;
@@ -30,9 +30,9 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         // Display shortcut panel
         let chunks = Layout::default()
             .constraints([
-                Constraint::Percentage(15),
-                Constraint::Percentage(70),
-                Constraint::Percentage(15),
+                Constraint::Percentage(5),
+                Constraint::Percentage(90),
+                Constraint::Percentage(5),
             ])
             .direction(Direction::Horizontal)
             .split(f.area());
@@ -665,46 +665,89 @@ fn add_edited(msg: &Message, out: &mut dyn fmt::Write) {
     }
 }
 
-fn draw_help(f: &mut Frame, app: &mut App, area: Rect) {
-    let modes = vec![
+fn help_commands<'a>() -> Vec<Line<'a>> {
+    let commands = <Command as strum::IntoEnumIterator>::iter()
+        .map(|cmd| {
+            (
+                strum::EnumProperty::get_str(&cmd, "usage")
+                    .unwrap_or(&cmd.to_string())
+                    .to_string(),
+                strum::EnumProperty::get_str(&cmd, "desc")
+                    .unwrap_or("Undocumented")
+                    .to_string(),
+            )
+        })
+        .collect_vec();
+    let usage_len = commands.iter().map(|inf| inf.0.len()).max().unwrap_or(0);
+    let commands = commands
+        .iter()
+        .map(|inf| Line::raw(format!("{: <usage_len$}   {}", inf.0, inf.1)));
+    let mut v = vec![
+        Line::styled("Commands", Style::default().add_modifier(Modifier::BOLD)),
+        Line::default(),
+    ];
+    v.extend(commands);
+    v
+}
+
+fn bindings(app: &App) -> Vec<Line> {
+    vec![
         WindowMode::Normal,
         WindowMode::Anywhere,
         WindowMode::Help,
         WindowMode::ChannelModal,
         WindowMode::Multiline,
         WindowMode::MessageSelected,
+    ]
+    .iter()
+    .map(|mode| bindings_mode(app, mode))
+    .concat()
+}
+
+fn bindings_mode<'a>(app: &App, mode: &WindowMode) -> Vec<Line<'a>> {
+    let bindings = if let Some(kb) = app.mode_keybindings.get(mode) {
+        kb.iter()
+            .map(|(kc, cmd)| {
+                (
+                    kc.to_string(),
+                    cmd.to_string(),
+                    strum::EnumProperty::get_str(cmd, "desc")
+                        .unwrap_or("Undocumented")
+                        .to_string(),
+                )
+            })
+            .sorted()
+            .collect_vec()
+    } else {
+        Vec::default()
+    };
+    let kc_len = bindings.iter().map(|inf| inf.0.len()).max().unwrap_or(0);
+    let cmd_len = bindings.iter().map(|inf| inf.1.len()).max().unwrap_or(0);
+    let bindings = bindings.iter().map(|inf| {
+        Line::raw(format!(
+            "{: <kc_len$}  {: <cmd_len$}  {}",
+            inf.0, inf.1, inf.2
+        ))
+    });
+    let mut v = vec![
+        Line::default(),
+        Line::styled(
+            format!("Bindings for {mode} mode"),
+            Style::default().add_modifier(Modifier::BOLD),
+        ),
+        Line::default(),
     ];
-    let mode_shortcuts = modes
-        .iter()
-        .map(|mode| {
-            let mode_title = format!("==== Mode: {mode}");
-            let doc = if let Some(kb) = app.mode_keybindings.get(mode) {
-                kb.iter()
-                    .map(|(kc, cmd)| {
-                        let cmd_doc =
-                            strum::EnumProperty::get_str(cmd, "desc").unwrap_or("Undocumented");
-                        format!("{kc}: {cmd} ({cmd_doc})")
-                    })
-                    .join("\n")
-            } else {
-                "".into()
-            };
-            format!("{mode_title}\n{doc}")
-        })
-        .join("\n\n");
-    let commands = <Command as strum::IntoEnumIterator>::iter()
-        .map(|cmd| {
-            format!(
-                "{}    {}",
-                &strum::EnumProperty::get_str(&cmd, "usage").unwrap_or(&cmd.to_string()),
-                &strum::EnumProperty::get_str(&cmd, "desc").unwrap_or("Undocumented")
-            )
-        })
-        .join("\n");
-    let commands = Paragraph::new(commands + "\n\n" + &mode_shortcuts)
+    v.extend(bindings);
+    v
+}
+
+fn draw_help(f: &mut Frame, app: &mut App, area: Rect) {
+    let mut command_bindings = help_commands();
+    command_bindings.extend(bindings(app));
+    let command_bindings = Paragraph::new(Text::from(command_bindings))
         .block(Block::bordered().title("Available commands and configured shortcuts"))
         .scroll(app.help_scroll);
-    f.render_widget(commands, area);
+    f.render_widget(command_bindings, area);
 }
 
 fn displayed_quote(names: &NameResolver, quote: &Message) -> Option<String> {

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -701,8 +701,9 @@ fn draw_help(f: &mut Frame, app: &mut App, area: Rect) {
             )
         })
         .join("\n");
-    let commands = Paragraph::new(commands + "\n" + &mode_shortcuts)
-        .block(Block::bordered().title("Available commands and configured shortcuts"));
+    let commands = Paragraph::new(commands + "\n\n" + &mode_shortcuts)
+        .block(Block::bordered().title("Available commands and configured shortcuts"))
+        .scroll(app.help_scroll);
     f.render_widget(commands, area);
 }
 


### PR DESCRIPTION
This fixes most of the points in #315 as well an issue that caused all `select_message` commands to be parsed as `select_message previous_entry`.

- [X] Allow scrolling in the help menu
- [X] Add default keybindings for scrolling the help menu
- [X] Enhance structure of help screen
- [X] Update commands and keybindings in README.md
- [X] Consume key events while in help mode to prevent simple key presses or Enter to be passed through

Overscroll prevention, wrapping or horizontal scrolling, and mouse wheel support for the help panel are not yet implemented.