### PR TITLE
populate name cache on startup

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -121,6 +121,13 @@ impl ChannelId {
         Ok(Self::Group(group_id))
     }
 
+    pub(crate) fn user(&self) -> Option<Uuid> {
+        match self {
+            ChannelId::User(uuid) => Some(*uuid),
+            _ => None,
+        }
+    }
+
     pub(crate) fn is_user(&self) -> bool {
         matches!(self, ChannelId::User(_))
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,6 +134,7 @@ async fn run_single_threaded(relink: bool) -> anyhow::Result<()> {
     sync_from_signal(&*signal_manager, &mut *storage);
 
     let (mut app, mut app_events) = App::try_new(config, signal_manager.clone_boxed(), storage)?;
+    app.populate_names_cache();
 
     // sync task can be only spawned after we start to listen to message, because it relies on
     // message sender to be running


### PR DESCRIPTION
This is a preparation for the presage changes that will require an async operation to lookup the name of a user.