### PR TITLE
Don't relink implicitly when the manager cannot be loaded.

### DIFF
--- a/src/signal/mod.rs
+++ b/src/signal/mod.rs
@@ -51,10 +51,15 @@ pub async fn ensure_linked_device(
 
     if !relink {
         if let Some(config) = config.clone() {
-            if let Ok(manager) = presage::Manager::load_registered(store.clone()).await {
-                // done loading manager from store
-                return Ok((Box::new(PresageManager::new(manager)), config));
-            }
+            match presage::Manager::load_registered(store.clone()).await {
+                Ok(manager) => {
+                    // done loading manager from store
+                    return Ok((Box::new(PresageManager::new(manager)), config));
+                }
+                Err(e) => {
+                    bail!("error loading manager. Try again later or run with --relink to force relink: {}", e)
+                }
+            };
         }
     }
 


### PR DESCRIPTION
Fixes #337. This avoids unintended relinks when encountering network issues.
