### PR TITLE
feat: add command for opening file attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ end_of_line
 delete_character previous
 edit_message
 open_url
+open_file
 ```
 
 ### Example configuration

--- a/src/app.rs
+++ b/src/app.rs
@@ -320,6 +320,9 @@ impl App {
             Command::OpenUrl => {
                 self.try_open_url();
             }
+            Command::OpenFile => {
+                self.try_open_file();
+            }
             Command::DeleteCharacter(MoveDirection::Previous) => {
                 self.get_input().on_backspace();
             }
@@ -402,6 +405,25 @@ impl App {
             .message(MessageId::new(*channel_id, *arrived_at))?;
         let re = self.url_regex.compiled();
         open_url(&message, re)?;
+        self.reset_message_selection();
+        Some(())
+    }
+
+    /// Tries to open the first file attachment in the selected message.
+    ///
+    /// Does nothing if no message is selected and the message contains no attachments.
+    fn try_open_file(&mut self) -> Option<()> {
+        // Note: to make the borrow checker happy, we have to use distinct fields here, and no
+        // methods that borrow self mutably.
+        let channel_id = self.channels.selected_item()?;
+        let messages = self.messages.get(channel_id)?;
+        let idx = messages.state.selected()?;
+        let idx = messages.items.len().checked_sub(idx + 1)?;
+        let arrived_at = messages.items.get(idx)?;
+        let message = self
+            .storage
+            .message(MessageId::new(*channel_id, *arrived_at))?;
+        open_file(&message)?;
         self.reset_message_selection();
         Some(())
     }
@@ -1650,6 +1672,15 @@ fn open_url(message: &Message, url_regex: &Regex) -> Option<()> {
     Some(())
 }
 
+fn open_file(message: &Message) -> Option<()> {
+    let attachment = message.attachments.first()?;
+    let file: &Path = attachment.filename.as_ref();
+    if let Err(error) = opener::open(file) {
+        let path = file.display().to_string();
+        error!(path, %error, "failed to open");
+    }
+    Some(())
+}
 fn notification_text_for_attachments(attachments: &[Attachment]) -> Option<String> {
     match attachments.len() {
         0 => None,

--- a/src/command.rs
+++ b/src/command.rs
@@ -223,6 +223,8 @@ pub enum Command {
     EditMessage,
     #[strum(props(desc = "Try to open the first url in the selected message"))]
     OpenUrl,
+    #[strum(props(desc = "Try to open the first file attachment of the selected message"))]
+    OpenFile,
     // ReplyMessage,
     // DeleteMessage,
 }


### PR DESCRIPTION
Adds a new command `open_file` that will open the first attachment on the message. It basically works the same as the existing `open_url` command but will just open the first attachment in the message rather than the first url. 

I'm mostly using it to just open images that I receive, and so it semi-addresses https://github.com/boxdot/gurk-rs/issues/90