### PR TITLE
feat: render qr code into a temporary png file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1730,6 +1730,7 @@ dependencies = [
  "presage-store-sled",
  "prost",
  "qr2term",
+ "qrcode",
  "quickcheck",
  "quickcheck_macros",
  "ratatui",
@@ -2342,7 +2343,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3549,6 +3550,9 @@ name = "qrcode"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
+dependencies = [
+ "image",
+]
 
 [[package]]
 name = "quick-xml"
@@ -5435,7 +5439,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ tempfile = "3.14.0"
 crokey = "1.1.0"
 strum_macros = "0.26.4"
 strum = { version = "0.26.3", features = ["derive"] }
+qrcode = { version = "0.14.1", default-features = false, features = ["image"] }
 
 [package.metadata.cargo-machete]
 # not used directly; brings sqlcipher capabilities to sqlite

--- a/src/signal/mod.rs
+++ b/src/signal/mod.rs
@@ -3,9 +3,15 @@ mod r#impl;
 mod manager;
 pub mod test;
 
-use anyhow::{bail, Context as _};
+use std::path::Path;
+
+use anyhow::{anyhow, bail, Context as _};
+use futures_channel::oneshot;
+use image::Luma;
 use presage::{libsignal_service::configuration::SignalServers, model::identity::OnNewIdentity};
 use presage_store_sled::{MigrationConflictStrategy, SledStore};
+use tracing::error;
+use url::Url;
 
 use crate::config::{self, Config};
 
@@ -78,25 +84,25 @@ pub async fn ensure_linked_device(
     let device_name = format!("gurk{at_hostname}");
     println!("Linking new device with device name: {device_name}");
 
-    let (tx, rx) = futures_channel::oneshot::channel();
-    let (mut manager, _) = tokio::try_join!(
-        async move {
-            presage::Manager::link_secondary_device(
-                store,
-                SignalServers::Production,
-                device_name.clone(),
-                tx,
-            )
-            .await
-            .map_err(anyhow::Error::from)
-        },
-        async move {
-            match rx.await {
-                Ok(url) => qr2term::print_qr(url.to_string()).context("failed to generated qr"),
-                Err(e) => bail!("error linking device: {}", e),
-            }
-        }
-    )?;
+    let (tx, rx) = oneshot::channel();
+
+    let link_task = async move {
+        presage::Manager::link_secondary_device(
+            store,
+            SignalServers::Production,
+            device_name.clone(),
+            tx,
+        )
+        .await
+        .map_err(anyhow::Error::from)
+    };
+
+    let tempdir = tempfile::tempdir().context("failed to create tempdir")?;
+    let path = tempdir.path().join("qrcode.png");
+    let qrcode_task = gen_qr_code(rx, &path);
+
+    let (mut manager, _) = tokio::try_join!(link_task, qrcode_task)?;
+    drop(tempdir); // make sure tempdir is dropped *after* qrcode_task
 
     // get profile
     let phone_number = manager
@@ -128,4 +134,28 @@ pub async fn ensure_linked_device(
     };
 
     Ok((Box::new(PresageManager::new(manager)), config))
+}
+
+async fn gen_qr_code(rx: oneshot::Receiver<Url>, path: &Path) -> anyhow::Result<()> {
+    let url = rx
+        .await
+        .map_err(|e| anyhow!("error linking device {}", e))?;
+
+    if let Err(error) = save_qr_code_png(&url, path) {
+        error!(%error, "failed to generate PNG QR code");
+    } else {
+        println!("QR code saved to {}", path.display());
+    }
+
+    qr2term::print_qr(url.to_string()).context("failed to generated qr")?;
+
+    Ok(())
+}
+
+fn save_qr_code_png(url: &Url, path: &Path) -> anyhow::Result<()> {
+    let image = qrcode::QrCode::new(url.to_string())?
+        .render::<Luma<u8>>()
+        .build();
+    image.save(&path)?;
+    Ok(())
 }


### PR DESCRIPTION
The path to the png is shown next to the QR code rendered to the terminal.

Closes #357