### PR TITLE
feat: make passphrase obligatory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,6 +774,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
+ "unicode-width 0.2.0",
  "windows-sys 0.59.0",
 ]
 
@@ -1157,6 +1158,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.91",
+]
+
+[[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror 1.0.69",
+ "zeroize",
 ]
 
 [[package]]
@@ -1697,7 +1711,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "gurk"
-version = "0.6.4"
+version = "0.7.0-dev"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -1709,6 +1723,7 @@ dependencies = [
  "criterion",
  "crokey",
  "crossterm",
+ "dialoguer",
  "dirs",
  "emojis",
  "futures-channel",
@@ -1757,6 +1772,7 @@ dependencies = [
  "url",
  "uuid",
  "whoami",
+ "zeroize",
 ]
 
 [[package]]
@@ -4151,6 +4167,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6001,6 +6023,7 @@ version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 dependencies = [
+ "serde",
  "zeroize_derive",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gurk"
 description = "Signal messenger client for terminal"
-version = "0.6.4"
+version = "0.7.0-dev"
 authors = ["boxdot <d@zerovolt.org>"]
 edition = "2024"
 keywords = ["signal", "tui"]
@@ -96,6 +96,8 @@ tokio-util = { version = "0.7.13", features = ["rt"] }
 qrcode = { version = "0.14.1", default-features = false, features = ["image"] }
 sha2 = "0.10.8"
 strip-ansi-escapes = "0.2.1"
+dialoguer = "0.11.0"
+zeroize = { version = "1.8.1", features = ["derive", "serde"] }
 
 [package.metadata.cargo-machete]
 # not used directly; brings sqlcipher capabilities to sqlite

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,7 @@ use url::Url;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use crate::command::ModeKeybindingConfig;
+use crate::{command::ModeKeybindingConfig, passphrase::Passphrase};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Config {
@@ -35,7 +35,7 @@ pub struct Config {
     pub sqlite: SqliteConfig,
     #[serde(default)]
     /// If set, enables encryption of the key store and messages database
-    pub passphrase: Option<String>,
+    pub passphrase: Option<Passphrase>,
     /// If set, the full message text will be colored, not only the author name
     #[serde(default)]
     pub colored_messages: bool,
@@ -118,6 +118,11 @@ impl Config {
     /// If no config is found returns `None`.
     pub(crate) fn load_installed() -> anyhow::Result<Option<LoadedConfig>> {
         installed_config().map(Self::load).transpose()
+    }
+
+    pub fn load_installed_passphrase() -> anyhow::Result<Option<Passphrase>> {
+        let loaded = Self::load_installed()?;
+        Ok(loaded.and_then(|c| c.config.passphrase))
     }
 
     /// Saves a new config file in case it does not exist.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub(crate) mod emoji;
 pub mod event;
 mod handlers;
 pub mod input;
+pub mod passphrase;
 pub mod receipt;
 pub mod shortcuts;
 pub mod signal;

--- a/src/passphrase.rs
+++ b/src/passphrase.rs
@@ -23,7 +23,7 @@ impl AsRef<str> for Passphrase {
 
 impl fmt::Debug for Passphrase {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("Passphrase").finish_non_exhaustive()
+        f.write_str("Passphrase(<redacted>)")
     }
 }
 
@@ -51,7 +51,7 @@ mod tests {
 
     #[test]
     fn test_passphrase_debug() {
-        let passphrase = Passphrase::new("secret".to_owned());
-        assert_eq!(format!("{:?}", passphrase), "Passphrase(..)");
+        let passphrase = Passphrase::new("secret").unwrap();
+        assert_eq!(format!("{:?}", passphrase), "Passphrase(<redacted>)");
     }
 }

--- a/src/passphrase.rs
+++ b/src/passphrase.rs
@@ -1,0 +1,57 @@
+use std::{fmt, str::FromStr};
+
+use anyhow::ensure;
+use serde::{Deserialize, Deserializer, Serialize, de};
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+#[derive(Clone, PartialEq, Eq, Zeroize, ZeroizeOnDrop, Serialize)]
+pub struct Passphrase(String);
+
+impl Passphrase {
+    pub fn new(passphrase: impl Into<String>) -> anyhow::Result<Self> {
+        let passphrase = passphrase.into();
+        ensure!(!passphrase.is_empty(), "passphrase cannot be empty");
+        Ok(Self(passphrase))
+    }
+}
+
+impl AsRef<str> for Passphrase {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for Passphrase {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Passphrase").finish_non_exhaustive()
+    }
+}
+
+impl FromStr for Passphrase {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::new(s)
+    }
+}
+
+impl<'de> Deserialize<'de> for Passphrase {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Self::new(s).map_err(de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_passphrase_debug() {
+        let passphrase = Passphrase::new("secret".to_owned());
+        assert_eq!(format!("{:?}", passphrase), "Passphrase(..)");
+    }
+}


### PR DESCRIPTION
A passphrase is now mandatory, therefore data and signal storage are always encrypted. If no passphrase is specified as a CLI argument or in the config, the user will be prompted at startup.