### PR TITLE
feat: add onboarding flow when there is no config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,9 +767,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -801,6 +801,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,7 +823,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -826,7 +836,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "libc",
 ]
 
@@ -1720,6 +1730,7 @@ dependencies = [
  "base64",
  "chrono",
  "clap",
+ "console",
  "criterion",
  "crokey",
  "crossterm",
@@ -1751,6 +1762,7 @@ dependencies = [
  "ratatui",
  "regex",
  "scopeguard",
+ "security-framework",
  "serde",
  "serde_json",
  "sha2",
@@ -4034,6 +4046,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation 0.10.0",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,8 @@ strip-ansi-escapes = "0.2.1"
 dialoguer = "0.11.0"
 zeroize = { version = "1.8.1", features = ["derive", "serde"] }
 console = "0.15.11"
+
+[target.'cfg(target_os = "macos")'.dependencies]
 security-framework = "3.2.0"
 
 [package.metadata.cargo-machete]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,8 @@ sha2 = "0.10.8"
 strip-ansi-escapes = "0.2.1"
 dialoguer = "0.11.0"
 zeroize = { version = "1.8.1", features = ["derive", "serde"] }
+console = "0.15.11"
+security-framework = "3.2.0"
 
 [package.metadata.cargo-machete]
 # not used directly; brings sqlcipher capabilities to sqlite

--- a/benches/app.rs
+++ b/benches/app.rs
@@ -13,8 +13,7 @@ fn test_app() -> App {
         Config {
             notifications: false,
             ..Config::with_user(User {
-                name: "Tyler Durden".to_string(),
-                phone_number: "+0000000000".to_string(),
+                display_name: "Tyler Durden".to_string(),
             })
         },
         Box::new(SignalManagerMock::new()),

--- a/src/app.rs
+++ b/src/app.rs
@@ -179,7 +179,7 @@ impl App {
     pub fn name_by_id_cached(&self, id: Uuid) -> String {
         if self.user_id == id {
             // it's me
-            return self.config.user.name.clone();
+            return self.config.user.display_name.clone();
         };
 
         let cache = self.names_cache.take().unwrap_or_default();
@@ -223,7 +223,7 @@ impl App {
     pub async fn name_by_id(&self, id: Uuid) -> String {
         if self.user_id == id {
             // it's me
-            self.config.user.name.clone()
+            self.config.user.display_name.clone()
         } else {
             self.name_by_id_or_cache(id, |id| self.resolve_name(id))
                 .await
@@ -1298,7 +1298,7 @@ impl App {
         } else {
             let channel = Channel {
                 id: user_id.into(),
-                name: self.config.user.name.clone(),
+                name: self.config.user.display_name.clone(),
                 group_data: None,
                 unread_messages: 0,
                 typing: TypingSet::SingleTyping(false),
@@ -1764,8 +1764,7 @@ pub(crate) mod tests {
         );
 
         let user = User {
-            name: "Tyler Durden".to_string(),
-            phone_number: "+0000000000".to_string(),
+            display_name: "Tyler Durden".to_string(),
         };
         let (mut app, events) = App::try_new(
             Config::with_user(user),

--- a/src/config.rs
+++ b/src/config.rs
@@ -335,13 +335,13 @@ mod tests {
     }
 
     fn example_config_with_random_paths(dir: &TempDir) -> Config {
-        let data_path = dir.path().join("some-data-dir/some-other-dir/data.json");
-        assert!(!data_path.parent().unwrap().exists());
+        let data_dir = dir.path().join("some-data-dir/some-other-dir/data.json");
+        assert!(!data_dir.parent().unwrap().exists());
         let signal_db_path = dir.path().join("some-signal-db-dir/some-other-dir");
         assert!(!signal_db_path.exists());
 
         Config {
-            deprecated_data_path: data_path,
+            data_dir,
             signal_db_path,
             ..Config::with_user(example_user())
         }
@@ -374,7 +374,6 @@ mod tests {
         let file = NamedTempFile::new()?;
 
         assert!(config.save_new_at(file.path()).is_err());
-        assert!(!config.deprecated_data_path.parent().unwrap().exists()); // data path parent is not touched
         assert!(!config.signal_db_path.exists()); // signal path is not touched
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub(crate) mod emoji;
 pub mod event;
 mod handlers;
 pub mod input;
+pub mod onboarding;
 pub mod passphrase;
 pub mod receipt;
 pub mod shortcuts;

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -70,8 +70,8 @@ pub fn run() -> anyhow::Result<(Config, Passphrase)> {
         PassphraseStorage::ConfigFile => {
             config.passphrase = Some(passphrase.clone());
         }
+        #[cfg(target_os = "macos")]
         PassphraseStorage::Keychain => {
-            #[cfg(target_os = "macos")]
             passphrase.store_in_keychain(&config.user.display_name)?;
         }
         PassphraseStorage::DontStore => {}

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -1,0 +1,120 @@
+use dialoguer::{Input, Password, Select, theme::ColorfulTheme};
+
+use crate::{
+    config::{Config, User},
+    passphrase::Passphrase,
+};
+
+pub fn run() -> anyhow::Result<(Config, Passphrase)> {
+    let theme = ColorfulTheme::default();
+
+    println!("Welcome to {}!", theme.prompt_style.apply_to("gurk"));
+
+    println!();
+    println!("Please enter your display name:");
+    println!(
+        "{}",
+        theme.hint_style.apply_to(
+            "The display name is only used within the app to identify the user locally. \
+            It is not shared with other users or transmitted over the network."
+        )
+    );
+
+    let display_name: String = loop {
+        let display_name: String = Input::with_theme(&theme)
+            .with_prompt("Display name")
+            .interact_text()?;
+        if !display_name.is_empty() {
+            break display_name;
+        }
+    };
+
+    println!();
+    println!("Please enter a passphrase:");
+    println!(
+        "{}",
+        theme.hint_style.apply_to(
+            "The passphrase will be used to encrypt local (sqlite) databases \
+            containing your messages and chats, Signal sessions and encryption keys."
+        )
+    );
+
+    let passphrase: Passphrase = loop {
+        let passphrase: String = Password::with_theme(&theme)
+            .with_prompt("Passphrase")
+            .with_confirmation("Confirm", "Passphrase mismatching")
+            .allow_empty_password(false)
+            .interact()?;
+        match Passphrase::new(passphrase.clone()) {
+            Ok(value) => break value,
+            Err(e) => {
+                println!("Invalid passphrase: {}", e);
+            }
+        }
+    };
+
+    println!();
+    let passphrase_storage = Select::with_theme(&theme)
+        .with_prompt("Where do you want to store your passphrase?")
+        .items(&[
+            "Config file",
+            #[cfg(target_os = "macos")]
+            "Keychain (macOS)",
+            "Don't store it (prompt on startup or CLI argument)",
+        ])
+        .interact()?;
+    let passphrase_storage = PassphraseStorage::from(passphrase_storage);
+
+    let mut config = Config::with_user(User { display_name });
+    match passphrase_storage {
+        PassphraseStorage::ConfigFile => {
+            config.passphrase = Some(passphrase.clone());
+        }
+        PassphraseStorage::Keychain => {
+            #[cfg(target_os = "macos")]
+            passphrase.store_in_keychain(&config.user.display_name)?;
+        }
+        PassphraseStorage::DontStore => {}
+    }
+
+    let config_path = config.save_new()?;
+
+    println!();
+    println!(
+        "Configuration is saved to: {}",
+        theme.values_style.apply_to(config_path.display())
+    );
+    println!(
+        "Messages and attachments will be saved to: {}",
+        theme.values_style.apply_to(config.data_dir.display())
+    );
+
+    Ok((config, passphrase))
+}
+
+enum PassphraseStorage {
+    #[cfg(target_os = "macos")]
+    Keychain,
+    ConfigFile,
+    DontStore,
+}
+
+impl From<usize> for PassphraseStorage {
+    fn from(value: usize) -> Self {
+        #[cfg(target_os = "macos")]
+        {
+            match value {
+                0 => PassphraseStorage::Keychain,
+                1 => PassphraseStorage::ConfigFile,
+                2 => PassphraseStorage::DontStore,
+                _ => unreachable!("logic error"),
+            }
+        }
+        #[cfg(not(target_os = "macos"))]
+        match value {
+            0 => PassphraseStorage::ConfigFile,
+            1 => PassphraseStorage::DontStore,
+            _ => unreachable!("logic error"),
+        }
+    }
+}

--- a/src/passphrase.rs
+++ b/src/passphrase.rs
@@ -1,17 +1,68 @@
 use std::{fmt, str::FromStr};
 
 use anyhow::ensure;
+use dialoguer::{Password, theme::ColorfulTheme};
 use serde::{Deserialize, Deserializer, Serialize, de};
 use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
+
+use crate::config::Config;
+
+#[cfg(target_os = "macos")]
+const KEYCHAIN_SERVICE_NAME: &str = "gurk";
 
 #[derive(Clone, PartialEq, Eq, Zeroize, ZeroizeOnDrop, Serialize)]
 pub struct Passphrase(String);
 
 impl Passphrase {
+    /// Creates a new passphrase from a string.
+    ///
+    /// Checks that the passphrase is not empty.
     pub fn new(passphrase: impl Into<String>) -> anyhow::Result<Self> {
         let passphrase = passphrase.into();
         ensure!(!passphrase.is_empty(), "passphrase cannot be empty");
         Ok(Self(passphrase))
+    }
+
+    /// Gets the passphrase from difference sources in the following order:
+    ///
+    /// 1. CLI argument
+    /// 2. config file
+    /// 3. Keychain (macOS only)
+    /// 3. prompt for passphrase
+    pub fn get(
+        passphrase_cli: Option<Passphrase>,
+        config: &mut Config,
+    ) -> anyhow::Result<Passphrase> {
+        if let Some(passphrase) = passphrase_cli {
+            return Ok(passphrase);
+        }
+
+        if let Some(passphrase) = config.passphrase.take() {
+            return Ok(passphrase);
+        }
+
+        #[cfg(target_os = "macos")]
+        if let Ok(value) = security_framework::passwords::get_generic_password(
+            KEYCHAIN_SERVICE_NAME,
+            &config.user.display_name,
+        ) {
+            return Passphrase::new(String::from_utf8(value)?);
+        }
+
+        let value = Password::with_theme(&ColorfulTheme::default())
+            .with_prompt("Enter passphrase")
+            .interact()?;
+        Passphrase::new(value)
+    }
+
+    pub(crate) fn store_in_keychain(&self, user: &str) -> anyhow::Result<()> {
+        use anyhow::Context;
+        security_framework::passwords::set_generic_password(
+            KEYCHAIN_SERVICE_NAME,
+            user,
+            self.0.as_bytes(),
+        )
+        .context("Failed to store passphrase to keychain")
     }
 
     pub(crate) fn sqlite_string(&self) -> Zeroizing<String> {

--- a/src/passphrase.rs
+++ b/src/passphrase.rs
@@ -55,6 +55,7 @@ impl Passphrase {
         Passphrase::new(value)
     }
 
+    #[cfg(target_os = "macos")]
     pub(crate) fn store_in_keychain(&self, user: &str) -> anyhow::Result<()> {
         use anyhow::Context;
         security_framework::passwords::set_generic_password(

--- a/src/signal/mod.rs
+++ b/src/signal/mod.rs
@@ -5,19 +5,16 @@ pub mod test;
 
 use std::path::Path;
 
-use anyhow::{Context as _, anyhow, bail};
+use anyhow::{Context as _, anyhow};
 use futures_channel::oneshot;
 use image::Luma;
 use presage::{libsignal_service::configuration::SignalServers, model::identity::OnNewIdentity};
 use presage_store_sled::{MigrationConflictStrategy, SledStore};
 use tokio_util::task::LocalPoolHandle;
-use tracing::{error, warn};
+use tracing::error;
 use url::Url;
 
-use crate::{
-    config::{self, Config, DeprecatedConfigKey, DeprecatedKeys, LoadedConfig},
-    passphrase::Passphrase,
-};
+use crate::{config::Config, passphrase::Passphrase};
 
 use self::r#impl::PresageManager;
 pub use self::manager::{Attachment, ResolvedGroup, SignalManager};
@@ -42,33 +39,11 @@ pub type GroupIdentifierBytes = [u8; GROUP_IDENTIFIER_LEN];
 pub async fn ensure_linked_device(
     relink: bool,
     local_pool: LocalPoolHandle,
+    config: &Config,
     passphrase: &Passphrase,
-) -> anyhow::Result<(Box<dyn SignalManager + Send>, Config)> {
-    let config = Config::load_installed()?;
-
-    // warn about deprecated keys
-    let config = config.map(
-        |LoadedConfig {
-             config,
-             deprecated_keys: DeprecatedKeys { file_path, keys },
-         }| {
-            if !keys.is_empty() {
-                println!("In '{}':", file_path.display());
-                for DeprecatedConfigKey { key, message } in keys {
-                    warn!(key, message, "deprecated config key");
-                    println!("deprecated config key: {key}, {message}");
-                }
-            }
-            config
-        },
-    );
-
-    let db_path = config
-        .as_ref()
-        .map(|c| c.signal_db_path.clone())
-        .unwrap_or_else(config::default_signal_db_path);
+) -> anyhow::Result<Box<dyn SignalManager + Send>> {
     let store = SledStore::open_with_passphrase(
-        db_path,
+        &config.signal_db_path,
         Some(passphrase),
         MigrationConflictStrategy::BackupAndDrop,
         OnNewIdentity::Trust,
@@ -76,24 +51,26 @@ pub async fn ensure_linked_device(
     .await?;
 
     if !relink {
-        if let Some(config) = config.clone() {
-            match presage::Manager::load_registered(store.clone()).await {
-                Ok(manager) => {
-                    // done loading manager from store
-                    return Ok((Box::new(PresageManager::new(manager, local_pool)), config));
-                }
-                Err(e) => {
-                    bail!(
-                        "error loading manager. Try again later or run with --relink to force relink: {}",
-                        e
-                    )
-                }
-            };
-        }
+        let manager = presage::Manager::load_registered(store).await.context(
+            "error loading manager. Try again later or run with --relink to force relink",
+        )?;
+        // done loading manager from store
+        Ok(Box::new(PresageManager::new(
+            manager,
+            config.data_dir.clone(),
+            local_pool,
+        )))
+    } else {
+        relink_device(local_pool, config, store).await
     }
+}
 
-    // faulty manager, or no config, or explicit relink
-    // => link device
+async fn relink_device(
+    local_pool: LocalPoolHandle,
+    config: &Config,
+    store: SledStore,
+) -> anyhow::Result<Box<dyn SignalManager + Send>> {
+    // explicit relink => link device
     let at_hostname = hostname::get()
         .ok()
         .and_then(|hostname| {
@@ -124,39 +101,15 @@ pub async fn ensure_linked_device(
     let path = tempdir.path().join("qrcode.png");
     let qrcode_task = gen_qr_code(rx, &path);
 
-    let (mut manager, _) = tokio::try_join!(link_task, qrcode_task)?;
-    drop(tempdir); // make sure tempdir is dropped *after* qrcode_task
+    let (manager, _) = tokio::try_join!(link_task, qrcode_task)?;
+    drop(tempdir);
+    // make sure tempdir is dropped *after* qrcode_task
 
-    // get profile
-    let phone_number = manager
-        .registration_data()
-        .phone_number
-        .format()
-        .mode(phonenumber::Mode::E164)
-        .to_string();
-    let profile = manager
-        .retrieve_profile()
-        .await
-        .context("failed to get the user profile")?;
-    let name = profile
-        .name
-        .map(|name| name.given_name)
-        .unwrap_or_else(whoami::username);
-
-    let config = if let Some(config) = config {
-        // check that config fits the profile
-        if config.user.phone_number != phone_number {
-            bail!("Wrong phone number in the config. Please adjust it.");
-        }
-        config
-    } else {
-        let user = config::User { name, phone_number };
-        let config = config::Config::with_user(user);
-        config.save_new().context("failed to init config file")?;
-        config
-    };
-
-    Ok((Box::new(PresageManager::new(manager, local_pool)), config))
+    Ok(Box::new(PresageManager::new(
+        manager,
+        config.data_dir.clone(),
+        local_pool,
+    )))
 }
 
 async fn gen_qr_code(rx: oneshot::Receiver<Url>, path: &Path) -> anyhow::Result<()> {


### PR DESCRIPTION
Onboarding consists of:

- displaying a welcome message
- asking for a display name
- asking for a passphrase
- asking where to store the passphrase

On macOS, additionally allow storing the passphrase in the keychain. Also, attempt to load it from the keychain if no passphrase is provided as a CLI argument or stored in the config file.

Additionally, phone number was removed from config. Also the default config does not save paths anymore, if they have default values. In particular, this makes the config portable.

![image](https://github.com/user-attachments/assets/ff8dcdb3-8b9e-4340-b98e-4a282f9879e2)

Closes #370 
Closes #360 