### PR TITLE
fix: cache sender certificate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3280,7 +3280,7 @@ checksum = "94e851c7654eed9e68d7d27164c454961a616cf8c203d500607ef22c737b51bb"
 [[package]]
 name = "presage"
 version = "0.7.0-dev"
-source = "git+https://github.com/whisperfish/presage?rev=0da7b5774#0da7b57746b827bfb310f98a10a29e73d508e742"
+source = "git+https://github.com/whisperfish/presage?rev=d3a760088#d3a760088617b657b41ccd4f43e4629e3c3188ac"
 dependencies = [
  "base64",
  "bytes",
@@ -3302,7 +3302,7 @@ dependencies = [
 [[package]]
 name = "presage-store-sqlite"
 version = "0.1.0"
-source = "git+https://github.com/whisperfish/presage?rev=0da7b5774#0da7b57746b827bfb310f98a10a29e73d508e742"
+source = "git+https://github.com/whisperfish/presage?rev=d3a760088#d3a760088617b657b41ccd4f43e4629e3c3188ac"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3831,9 +3831,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.20"
+version = "0.23.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
+checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
 dependencies = [
  "once_cell",
  "ring",
@@ -3854,18 +3854,19 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
  "web-time",
+ "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4703,9 +4704,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.42.0"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
+checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4719,9 +4720,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ debug = true
 dev = ["prost", "base64"]
 
 [dependencies]
-presage = { git = "https://github.com/whisperfish/presage", rev = "0da7b5774" }
-presage-store-sqlite = { git = "https://github.com/whisperfish/presage", rev = "0da7b5774" }
+presage = { git = "https://github.com/whisperfish/presage", rev = "d3a760088" }
+presage-store-sqlite = { git = "https://github.com/whisperfish/presage", rev = "d3a760088" }
 
 # dev feature dependencies
 prost = { version = "0.13.4", optional = true }
@@ -123,7 +123,7 @@ harness = false
 # presage-store-sqlite = { path = "../presage/presage-store-sqlite" }
 #
 # [patch."https://github.com/whisperfish/libsignal-service-rs"]
-# libsignal-service = { path = "../libsignal-service-rs/libsignal-service" }
+# libsignal-service = { path = "../libsignal-service-rs" }
 
 [patch.crates-io]
 # signal-protocol uses a fork of this library via the patch mechanism of cargo.


### PR DESCRIPTION
This commit upgrade presage including the fix for the cache of sender certificate. In particular, it fixes fetching of the sender certificate on every send message call.

Also includes offloading decryption of large attachments to another thread.