### PR TITLE
fix(publish): use latest ubuntu for musl

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,7 +61,7 @@ jobs:
         target:
           - x86_64-unknown-linux-musl
           - aarch64-unknown-linux-musl
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
       image: rust:alpine
       volumes:


### PR DESCRIPTION
I noticed publish workflow runs on my own fork would hang for musl, and when troubleshooting, I found that the GitHub runner is a version of Ubuntu that's no longer supported. Updating to `ubuntu-latest` (like everything else) seems to fix the issue.