### PR TITLE
fix: missing author after date separator

### DIFF
--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -341,8 +341,6 @@ fn draw_messages(f: &mut Frame, app: &mut App, area: Rect) {
     }
     let prefix = " ".repeat(prefix_width);
 
-    if channel.unread_messages > 0 {}
-
     // The day of the message at the bottom of the viewport
     let first_msg_timestamp = messages_to_render.clone().next().unwrap_or_default();
     let mut previous_msg_timestamp = first_msg_timestamp;


### PR DESCRIPTION
Also move "new messages" line into the message itself, which fixes the
offset error when opening attachments and quoting messages.