### PR TITLE
security: remove open url command

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,6 @@ beginning_of_line
 end_of_line
 delete_character previous|next
 edit_message
-open_url
 open_file
 toggle_mute_channel
 ```

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -17,9 +17,9 @@ use crate::command::{
 };
 use crate::data::Message;
 use crate::storage::MessageId;
-use crate::util::{ATTACHMENT_REGEX, URL_REGEX};
+use crate::util::ATTACHMENT_REGEX;
 
-use super::{App, HandleReactionOptions, open_file, open_url, to_emoji};
+use super::{App, HandleReactionOptions, open_file, to_emoji};
 
 impl App {
     async fn on_command(&mut self, command: Command) -> anyhow::Result<()> {
@@ -77,9 +77,6 @@ impl App {
                     self.add_reaction(idx, reaction).await;
                 }
             }
-            Command::OpenUrl => {
-                self.try_open_url();
-            }
             Command::OpenFile => {
                 self.try_open_file();
             }
@@ -124,7 +121,7 @@ impl App {
                             }
                         } else {
                             // input is empty
-                            self.try_open_url_or_file();
+                            self.try_open_file();
                         }
                     } else if self.select_channel.is_shown
                         && let Some(channel_id) = self.select_channel.selected_channel_id().copied()
@@ -150,20 +147,6 @@ impl App {
             }
         }
         Ok(())
-    }
-
-    fn try_open_url_or_file(&mut self) -> Option<()> {
-        self.try_open_url().or_else(|| self.try_open_file())
-    }
-
-    /// Tries to open the first url in the selected message.
-    ///
-    /// Does nothing if no message is selected and no url is contained in the message.
-    fn try_open_url(&mut self) -> Option<()> {
-        let message = self.selected_message()?;
-        open_url(&message, &URL_REGEX)?;
-        self.reset_message_selection();
-        Some(())
     }
 
     /// Tries to open the first file attachment in the selected message.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -6,7 +6,6 @@ use std::path::Path;
 
 use anyhow::Context as _;
 use itertools::Itertools;
-use regex::Regex;
 use tokio::sync::mpsc;
 use tracing::{debug, error, warn};
 use uuid::Uuid;
@@ -319,21 +318,6 @@ pub fn to_emoji(s: &str) -> Option<&str> {
         let s = s.strip_prefix(':')?.strip_suffix(':')?;
         Some(emojis::get_by_shortcode(s)?.as_str())
     }
-}
-
-pub(super) fn open_url(message: &Message, url_regex: &Regex) -> Option<()> {
-    let text = message.message.as_ref()?;
-    let m = url_regex.find(text)?;
-    let url = m.as_str();
-    let result = if let Some(path) = url.strip_prefix("file://") {
-        opener::open(Path::new(path))
-    } else {
-        opener::open(url)
-    };
-    if let Err(error) = result {
-        error!(url, %error, "failed to open");
-    }
-    Some(())
 }
 
 pub(super) fn open_file(message: &Message) -> Option<()> {

--- a/src/command.rs
+++ b/src/command.rs
@@ -221,8 +221,6 @@ pub enum Command {
     DeleteCharacter(MoveDirection),
     #[strum(props(desc = "Edit selected message"))]
     EditMessage,
-    #[strum(props(desc = "Try to open the first url in the selected message"))]
-    OpenUrl,
     #[strum(props(desc = "Try to open the first file attachment of the selected message"))]
     OpenFile,
     #[strum(props(desc = "Toggle mute for the selected channel"))]

--- a/src/util.rs
+++ b/src/util.rs
@@ -113,15 +113,6 @@ pub fn is_phone_number(s: impl AsRef<str>) -> bool {
 }
 
 // Based on Alacritty, APACHE-2.0 License
-pub(crate) static URL_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(
-        "(ipfs:|ipns:|magnet:|mailto:|gemini:|gopher:|https:|http:|news:|file:|git:|ssh:|ftp:)\
-     [^\u{0000}-\u{001F}\u{007F}-\u{009F}<>\"\\s{-}\\^⟨⟩`]+",
-    )
-    .unwrap()
-});
-
-// Based on Alacritty, APACHE-2.0 License
 pub(crate) static ATTACHMENT_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new("file:[^\u{0000}-\u{001F}\u{007F}-\u{009F}<>\"\\s{-}\\^⟨⟩`]+").unwrap()
 });


### PR DESCRIPTION
The command can be abused by a malicious contact. The contact could send
a message containing a link which looks like file://something and this
command would open the file. Even though it is only triggered by the
user, there still no need to have this feature. The user can open the
url via their terminal.