### PR TITLE
fix: remove stray previous() in select_next_channel

### DIFF
--- a/src/app/channel.rs
+++ b/src/app/channel.rs
@@ -31,7 +31,6 @@ impl App {
         self.channels.next();
         let new = self.channels.selected_item().copied();
         self.swap_channel_draft(old, new);
-        self.channels.previous();
         self.on_channel_changed();
     }
 


### PR DESCRIPTION
Fixes #532

PR #524 added `self.channels.previous()` after `self.channels.next()` in
`select_next_channel()`, which cancels the movement. The down arrow key
(and ctrl+j) no longer advance to the next channel.

Remove the erroneous `previous()` call to restore correct behavior.