### PR TITLE
fix: don't clear unread messages when navigating channels

### DIFF
--- a/src/app/channel.rs
+++ b/src/app/channel.rs
@@ -17,7 +17,6 @@ impl App {
     }
 
     pub fn select_previous_channel(&mut self) {
-        self.reset_unread_messages();
         let old = self.channels.selected_item().copied();
         self.channels.previous();
         let new = self.channels.selected_item().copied();
@@ -26,7 +25,6 @@ impl App {
     }
 
     pub fn select_next_channel(&mut self) {
-        self.reset_unread_messages();
         let old = self.channels.selected_item().copied();
         self.channels.next();
         let new = self.channels.selected_item().copied();


### PR DESCRIPTION
Previously, scrolling through channels with ctrl+j/k (or up/down) would
clear the unread counter for the channel being left. This meant simply
browsing the channel list would mark everything as read.

Now unread only clears on explicit interaction: sending a message,
adding a reaction, or clicking a channel with the mouse. This matches
the behavior of the official Signal clients.