### PR TITLE
chore: add AI assistant files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,14 @@ gurk.log
 Session.vim
 messages.raw.json
 test.sqlite
+
+# AI assistant files
+CLAUDE.md
+AGENTS.md
+.claude/
+.ai/
+.beads/
+.cursor/
+.aider*
+.copilot/
+audit.md


### PR DESCRIPTION
Prevents accidental commits of local AI tool configurations:

- `CLAUDE.md`, `AGENTS.md` - Claude Code / Anthropic
- `.claude/`, `.ai/` - AI config directories
- `.beads/` - Beads task tracking
- `.cursor/` - Cursor editor
- `.aider*` - Aider
- `.copilot/` - GitHub Copilot
- `audit.md` - AI audit logs