### PR TITLE
fix: expire typing indicators after 10 seconds

### DIFF
--- a/src/app/channel.rs
+++ b/src/app/channel.rs
@@ -194,7 +194,7 @@ impl App {
                 group_data: None,
                 unread_messages: 0,
                 muted: false,
-                typing: TypingSet::SingleTyping(false),
+                typing: TypingSet::SingleTyping(None),
                 expire_timer: None,
             };
             let channel = self.storage.store_channel(channel);
@@ -230,7 +230,7 @@ impl App {
                 group_data: None,
                 unread_messages: 0,
                 muted: false,
-                typing: TypingSet::SingleTyping(false),
+                typing: TypingSet::SingleTyping(None),
                 expire_timer: None,
             };
             let channel = self.storage.store_channel(channel);

--- a/src/app/message.rs
+++ b/src/app/message.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::cmp::Reverse;
 use std::collections::BTreeMap;
+use std::time::Instant;
 
 use anyhow::{Context as _, anyhow};
 use itertools::Itertools;
@@ -653,6 +654,20 @@ impl App {
         self.receipt_handler.step(self.signal_manager.as_ref());
     }
 
+    /// Expire typing indicators older than TYPING_TIMEOUT_SECS
+    pub fn expire_typing_indicators(&mut self) {
+        for channel_id in &self.channels.items {
+            if let Some(channel) = self.storage.channel(*channel_id) {
+                if channel.is_writing() {
+                    let mut channel = channel.into_owned();
+                    if channel.expire_typing() {
+                        self.storage.store_channel(channel);
+                    }
+                }
+            }
+        }
+    }
+
     fn handle_typing(
         &mut self,
         sender_uuid: Uuid,
@@ -666,13 +681,13 @@ impl App {
                 .channel(ChannelId::Group(gid))
                 .ok_or(())?
                 .into_owned();
-            if let TypingSet::GroupTyping(ref mut hash_set) = channel.typing {
+            if let TypingSet::GroupTyping(ref mut map) = channel.typing {
                 match action {
                     TypingAction::Started => {
-                        hash_set.insert(sender_uuid);
+                        map.insert(sender_uuid, Instant::now());
                     }
                     TypingAction::Stopped => {
-                        hash_set.remove(&sender_uuid);
+                        map.remove(&sender_uuid);
                     }
                 }
                 self.storage.store_channel(channel);
@@ -688,10 +703,10 @@ impl App {
             if let TypingSet::SingleTyping(_) = channel.typing {
                 match action {
                     TypingAction::Started => {
-                        channel.typing = TypingSet::SingleTyping(true);
+                        channel.typing = TypingSet::SingleTyping(Some(Instant::now()));
                     }
                     TypingAction::Stopped => {
-                        channel.typing = TypingSet::SingleTyping(false);
+                        channel.typing = TypingSet::SingleTyping(None);
                     }
                 }
                 self.storage.store_channel(channel);

--- a/src/app/message.rs
+++ b/src/app/message.rs
@@ -657,12 +657,12 @@ impl App {
     /// Expire typing indicators older than TYPING_TIMEOUT_SECS
     pub fn expire_typing_indicators(&mut self) {
         for channel_id in &self.channels.items {
-            if let Some(channel) = self.storage.channel(*channel_id) {
-                if channel.is_writing() {
-                    let mut channel = channel.into_owned();
-                    if channel.expire_typing() {
-                        self.storage.store_channel(channel);
-                    }
+            if let Some(channel) = self.storage.channel(*channel_id)
+                && channel.is_writing()
+            {
+                let mut channel = channel.into_owned();
+                if channel.expire_typing() {
+                    self.storage.store_channel(channel);
                 }
             }
         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -180,14 +180,11 @@ impl App {
     pub fn writing_people(&self, channel: &Channel) -> Option<String> {
         if channel.is_writing() {
             let uuids: Box<dyn Iterator<Item = Uuid>> = match &channel.typing {
-                TypingSet::GroupTyping(uuids) => Box::new(uuids.iter().copied()),
-                TypingSet::SingleTyping(a) => {
-                    if *a {
-                        Box::new(std::iter::once(channel.user_id().unwrap()))
-                    } else {
-                        Box::new(std::iter::empty())
-                    }
+                TypingSet::GroupTyping(map) => Box::new(map.keys().copied()),
+                TypingSet::SingleTyping(Some(_)) => {
+                    Box::new(std::iter::once(channel.user_id().unwrap()))
                 }
+                TypingSet::SingleTyping(None) => Box::new(std::iter::empty()),
             };
             Some(format!(
                 "[{}] writing...",

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,6 +1,7 @@
 //! Part of the app which is serialized
 
-use std::collections::HashSet;
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
 
 use anyhow::anyhow;
 use presage::libsignal_service::zkgroup::groups::{GroupMasterKey, GroupSecretParams};
@@ -25,18 +26,40 @@ pub struct Channel {
     pub expire_timer: Option<u32>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// Timeout for typing indicators (10 seconds per Signal protocol)
+pub const TYPING_TIMEOUT_SECS: u64 = 10;
+
+#[derive(Debug, Clone)]
 pub enum TypingSet {
-    SingleTyping(bool),
-    GroupTyping(HashSet<Uuid>),
+    /// For direct messages: None = not typing, Some(when) = typing since
+    SingleTyping(Option<Instant>),
+    /// For groups: maps user UUID to when they started typing
+    GroupTyping(HashMap<Uuid, Instant>),
 }
+
+impl PartialEq for TypingSet {
+    fn eq(&self, other: &Self) -> bool {
+        // Compare presence only, not timestamps
+        match (self, other) {
+            (TypingSet::SingleTyping(a), TypingSet::SingleTyping(b)) => {
+                a.is_some() == b.is_some()
+            }
+            (TypingSet::GroupTyping(a), TypingSet::GroupTyping(b)) => {
+                a.len() == b.len() && a.keys().all(|k| b.contains_key(k))
+            }
+            _ => false,
+        }
+    }
+}
+
+impl Eq for TypingSet {}
 
 impl TypingSet {
     pub fn new(is_group: bool) -> Self {
         if is_group {
-            Self::GroupTyping(Default::default())
+            Self::GroupTyping(HashMap::new())
         } else {
-            Self::SingleTyping(false)
+            Self::SingleTyping(None)
         }
     }
 }
@@ -52,19 +75,42 @@ pub struct GroupData {
 impl Channel {
     pub fn reset_writing(&mut self, user: Uuid) -> bool {
         match &mut self.typing {
-            TypingSet::GroupTyping(hash_set) => hash_set.remove(&user),
-            TypingSet::SingleTyping(true) => {
-                self.typing = TypingSet::SingleTyping(false);
+            TypingSet::GroupTyping(map) => map.remove(&user).is_some(),
+            TypingSet::SingleTyping(Some(_)) => {
+                self.typing = TypingSet::SingleTyping(None);
                 true
             }
-            TypingSet::SingleTyping(false) => false,
+            TypingSet::SingleTyping(None) => false,
         }
     }
 
     pub fn is_writing(&self) -> bool {
         match &self.typing {
-            TypingSet::GroupTyping(a) => !a.is_empty(),
-            TypingSet::SingleTyping(a) => *a,
+            TypingSet::GroupTyping(map) => !map.is_empty(),
+            TypingSet::SingleTyping(opt) => opt.is_some(),
+        }
+    }
+
+    /// Remove typing indicators older than the timeout. Returns true if any were removed.
+    pub fn expire_typing(&mut self) -> bool {
+        let timeout = Duration::from_secs(TYPING_TIMEOUT_SECS);
+        let now = Instant::now();
+
+        match &mut self.typing {
+            TypingSet::GroupTyping(map) => {
+                let before = map.len();
+                map.retain(|_, started| now.duration_since(*started) < timeout);
+                map.len() != before
+            }
+            TypingSet::SingleTyping(Some(started)) => {
+                if now.duration_since(*started) >= timeout {
+                    self.typing = TypingSet::SingleTyping(None);
+                    true
+                } else {
+                    false
+                }
+            }
+            TypingSet::SingleTyping(None) => false,
         }
     }
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -41,9 +41,7 @@ impl PartialEq for TypingSet {
     fn eq(&self, other: &Self) -> bool {
         // Compare presence only, not timestamps
         match (self, other) {
-            (TypingSet::SingleTyping(a), TypingSet::SingleTyping(b)) => {
-                a.is_some() == b.is_some()
-            }
+            (TypingSet::SingleTyping(a), TypingSet::SingleTyping(b)) => a.is_some() == b.is_some(),
             (TypingSet::GroupTyping(a), TypingSet::GroupTyping(b)) => {
                 a.len() == b.len() && a.keys().all(|k| b.contains_key(k))
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -284,6 +284,7 @@ async fn run(config: Config, passphrase: Passphrase, relink: bool) -> anyhow::Re
         match event {
             Some(Event::Tick) => {
                 app.step_receipts();
+                app.expire_typing_indicators();
                 expire_tick_counter += 1;
                 if expire_tick_counter >= 5 {
                     expire_tick_counter = 0;


### PR DESCRIPTION
Typing indicators now auto-expire after 10 seconds per Signal protocol.
Previously, `[T]` would persist forever if the `Stopped` message was lost.

## Changes

- `TypingSet` now stores `Instant` timestamps instead of just presence
- Added `Channel::expire_typing()` to remove stale indicators
- Added `App::expire_typing_indicators()` called every tick (~1s)
- Timeout constant `TYPING_TIMEOUT_SECS = 10`

## Test plan

- [x] `cargo test` passes
- [ ] Manual test: have contact start typing, close their app without sending → indicator should clear after 10s

Closes #151