### PR TITLE
Speed up database decryption on debug builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,14 @@ members = ["xtask"]
 # This speeds up `cargo xtask dist`.
 opt-level = 3
 
+[profile.dev.package.sqlcipher-crypto-provider]
+# This speeds up database decryption on debug builds
+opt-level = 3
+
+[profile.dev.package.sha2]
+# This speeds up database decryption on debug builds
+opt-level = 3
+
 [profile.release]
 debug = 0
 lto = "thin"


### PR DESCRIPTION
When I run the program in debug mode (like `cargo run`), it currently takes ~25 seconds with 100% CPU usage to decrypt the database on startup, while on release builds it takes closer to one second. This fix makes the debug build close to as fast as the release build.