### PR TITLE
Replace text with emoji while typing

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -154,7 +154,12 @@ impl App {
                 KeyCode::Esc if !self.reset_editing() => {
                     self.reset_message_selection();
                 }
-                KeyCode::Char(c) => self.get_input().put_char(c),
+                KeyCode::Char(c) => {
+                    self.get_input().put_char(c);
+                    if c == ':' {
+                        self.get_input().convert_emoji_on_colon();
+                    }
+                }
                 _ => {}
             }
         }

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,5 +1,7 @@
 //! Input box
 
+use unicode_width::UnicodeWidthStr;
+
 use crate::cursor::Cursor;
 
 /// Input box with data and a cursor
@@ -77,5 +79,37 @@ impl Input {
     pub fn take(&mut self) -> String {
         self.cursor = Default::default();
         std::mem::take(&mut self.data)
+    }
+
+    /// If the character just before the cursor is `:`, look backwards for a
+    /// matching opening `:` and check if it's a valid emoji shortcode. If so,
+    /// replace `:shortcode:` with the actual emoji and adjust cursor position.
+    pub fn convert_emoji_on_colon(&mut self) {
+        let idx = self.cursor.idx;
+        if idx < 1 || !self.data.is_char_boundary(idx) {
+            return;
+        }
+        if &self.data[idx - 1..idx] != ":" {
+            return;
+        }
+
+        let before = &self.data[..idx - 1];
+        let open_pos = match before.rfind(':') {
+            Some(p) => p,
+            None => return,
+        };
+
+        let shortcode = &self.data[open_pos + 1..idx - 1];
+        let Some(emoji) = emojis::get_by_shortcode(shortcode) else {
+            return;
+        };
+        let emoji_str = emoji.as_str();
+
+        let old_width = self.data[open_pos..idx].width();
+        let emoji_width = emoji_str.width();
+
+        self.cursor.col = self.cursor.col.saturating_sub(old_width - emoji_width);
+        self.cursor.idx = open_pos + emoji_str.len();
+        self.data.replace_range(open_pos..idx, emoji_str);
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -99,6 +99,14 @@ impl Input {
             None => return,
         };
 
+        // Only convert when the opening `:` starts a word, i.e. it is at the beginning of the input
+        // or preceded by whitespace. This avoids mangling code such as `xtask::shell::foobar`.
+        if let Some(prev) = self.data[..open_pos].chars().next_back()
+            && !prev.is_whitespace()
+        {
+            return;
+        }
+
         let shortcode = &self.data[open_pos + 1..idx - 1];
         let Some(emoji) = emojis::get_by_shortcode(shortcode) else {
             return;
@@ -111,5 +119,114 @@ impl Input {
         self.cursor.col = self.cursor.col.saturating_sub(old_width - emoji_width);
         self.cursor.idx = open_pos + emoji_str.len();
         self.data.replace_range(open_pos..idx, emoji_str);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cursor::Cursor;
+
+    /// Type `s` character by character, mirroring the app's key dispatch: after every `:` we
+    /// attempt an emoji conversion.
+    fn type_str(input: &mut Input, s: &str) {
+        for c in s.chars() {
+            input.put_char(c);
+            if c == ':' {
+                input.convert_emoji_on_colon();
+            }
+        }
+    }
+
+    #[test]
+    fn test_convert_emoji_basic() {
+        let mut input = Input::default();
+        type_str(&mut input, ":dog:");
+        assert_eq!(input.data, "🐶");
+        // idx = byte length of the emoji, col = display width, still on line 0
+        assert_eq!(input.cursor, Cursor::new("🐶".len(), 0, 2));
+    }
+
+    #[test]
+    fn test_convert_emoji_unknown_shortcode() {
+        let mut input = Input::default();
+        type_str(&mut input, ":nope:");
+        assert_eq!(input.data, ":nope:");
+        assert_eq!(input.cursor, Cursor::new(6, 0, 6));
+    }
+
+    #[test]
+    fn test_convert_emoji_double_colon() {
+        let mut input = Input::default();
+        type_str(&mut input, "::");
+        assert_eq!(input.data, "::");
+        assert_eq!(input.cursor, Cursor::new(2, 0, 2));
+    }
+
+    #[test]
+    fn test_convert_emoji_no_opening_colon() {
+        let mut input = Input::default();
+        type_str(&mut input, "dog:");
+        assert_eq!(input.data, "dog:");
+        assert_eq!(input.cursor, Cursor::new(4, 0, 4));
+    }
+
+    #[test]
+    fn test_convert_emoji_with_leading_text() {
+        let mut input = Input::default();
+        type_str(&mut input, "hi :dog:");
+        assert_eq!(input.data, "hi 🐶");
+        assert_eq!(input.cursor, Cursor::new("hi 🐶".len(), 0, 5));
+    }
+
+    #[test]
+    fn test_convert_emoji_requires_word_boundary() {
+        // Opening `:` glued to a preceding word must not trigger conversion,
+        // so paths like `xtask::shell::foobar` stay intact.
+        let mut input = Input::default();
+        type_str(&mut input, "a:dog:");
+        assert_eq!(input.data, "a:dog:");
+        assert_eq!(input.cursor, Cursor::new(6, 0, 6));
+
+        let mut input = Input::default();
+        type_str(&mut input, "xtask::shell::foobar");
+        assert_eq!(input.data, "xtask::shell::foobar");
+    }
+
+    #[test]
+    fn test_convert_emoji_after_newline() {
+        // The start of a line counts as a word boundary.
+        let mut input = Input::default();
+        type_str(&mut input, "foo\n:dog:");
+        assert_eq!(input.data, "foo\n🐶");
+        assert_eq!(input.cursor, Cursor::new("foo\n🐶".len(), 1, 2));
+    }
+
+    #[test]
+    fn test_convert_emoji_consecutive_needs_whitespace() {
+        // Whitespace-separated shortcodes both convert.
+        let mut input = Input::default();
+        type_str(&mut input, ":dog: :cat:");
+        assert_eq!(input.data, "🐶 🐱");
+        assert_eq!(input.cursor, Cursor::new("🐶 🐱".len(), 0, 5));
+
+        // Directly glued to the preceding emoji, the second one is not at a
+        // word boundary and stays as text.
+        let mut input = Input::default();
+        type_str(&mut input, ":dog::cat:");
+        assert_eq!(input.data, "🐶:cat:");
+    }
+
+    #[test]
+    fn test_convert_emoji_in_middle_of_text() {
+        // Cursor is moved back before the closing colon is typed, so text
+        // trails the replacement range.
+        let mut input = Input::default();
+        type_str(&mut input, "x y");
+        input.on_left();
+        type_str(&mut input, ":dog:");
+        assert_eq!(input.data, "x 🐶y");
+        // cursor sits right after the emoji, before the trailing `y`
+        assert_eq!(input.cursor, Cursor::new("x 🐶".len(), 0, 4));
     }
 }


### PR DESCRIPTION
Currently, you need to send the text containing emoji shortcodes for them to be replaced with actual emojis. This change makes it automatically replace them as you are typing, so `:smile:` becomes 😄 right as you type the second `:`.

I looked into showing a pop-up while typing with the different options, but that seems way more complex. Adding tab completion as a follow-up to this might be quite simple though.