### PR TITLE
fix: parse binary fields in Quote

### DIFF
--- a/src/app/message.rs
+++ b/src/app/message.rs
@@ -14,7 +14,7 @@ use presage::proto::{GroupContextV2, data_message::Delete, data_message::Reactio
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
-use crate::data::{BodyRange, ChannelId, Message, TypingAction, TypingSet};
+use crate::data::{BodyRange, ChannelId, Message, TypingAction, TypingSet, parse_uuid};
 use crate::receipt::{Receipt, ReceiptEvent};
 use crate::signal::{Attachment, GroupIdentifierBytes};
 use crate::storage::MessageId;
@@ -1017,14 +1017,6 @@ impl MessageExt for SyncMessage {
             ChannelId::from_master_key_bytes(group_v2.master_key.as_deref()?).ok()
         }
     }
-}
-
-/// First parse the binary field, then fallback to the string field
-fn parse_uuid(str_field: Option<&str>, binary_field: Option<&[u8]>) -> Option<Uuid> {
-    binary_field
-        .and_then(ServiceId::parse_from_service_id_binary)
-        .map(|sid| sid.raw_uuid())
-        .or_else(|| str_field.and_then(|s| s.parse().ok()))
 }
 
 trait SyncSentExt {

--- a/src/data.rs
+++ b/src/data.rs
@@ -3,6 +3,7 @@
 use std::collections::HashSet;
 
 use anyhow::anyhow;
+use presage::libsignal_service::protocol::ServiceId;
 use presage::libsignal_service::zkgroup::groups::{GroupMasterKey, GroupSecretParams};
 use presage::proto;
 use presage::proto::data_message::Quote;
@@ -329,7 +330,10 @@ impl Message {
 
     pub fn from_quote(quote: Quote) -> Option<Message> {
         Some(Message {
-            from_id: quote.author_aci?.parse().ok()?,
+            from_id: parse_uuid(
+                quote.author_aci.as_deref(),
+                quote.author_aci_binary.as_deref(),
+            )?,
             message: quote.text,
             arrived_at: quote.id?,
             quote: None,
@@ -356,4 +360,12 @@ impl Message {
             && self.reactions.is_empty()
             && self.quote.is_none()
     }
+}
+
+/// First parse the binary field, then fallback to the string field
+pub fn parse_uuid(str_field: Option<&str>, binary_field: Option<&[u8]>) -> Option<Uuid> {
+    binary_field
+        .and_then(ServiceId::parse_from_service_id_binary)
+        .map(|sid| sid.raw_uuid())
+        .or_else(|| str_field.and_then(|s| s.parse().ok()))
 }

--- a/src/signal/impl.rs
+++ b/src/signal/impl.rs
@@ -143,9 +143,10 @@ impl SignalManager for PresageManager {
 
         let quote = quote_message.map(|message| Quote {
             id: Some(message.arrived_at),
-            author_aci: Some(message.from_id.to_string()),
+            author_aci: None,
             text: message.message.clone(),
             body_ranges: message.body_ranges.iter().map(From::from).collect(),
+            author_aci_binary: Some(message.from_id.as_bytes().to_vec()),
             ..Default::default()
         });
         let quote_message = quote.clone().and_then(Message::from_quote).map(Box::new);


### PR DESCRIPTION
see also: https://github.com/boxdot/gurk-rs/pull/504

On modern clients, `Quote::author_aci` is `None`, with `Quote::author_aci_binary` being where the data lives. The logic of `Message::from_quote` caused these "modern quotes" to be dropped and not displayed. Instead, use `parse_uuid` to parse them, checking both `Quote::author_aci_binary` and `Quote::author_aci`.

Also, in outgoing messages, use `Quote::author_aci_binary` instead of `Quote::author_aci`, to be modern ourselves too. ([We already do this for reactions](https://github.com/boxdot/gurk-rs/blob/2d41dddd4eff6f64f8318157afcc1038bb7f8315/src/signal/impl.rs#L293-L294))